### PR TITLE
Add segmented control to event browse VC to display registered events, tap on profile picture or username in events detail VC now causes profile to appear, add pull-to-refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-t# Xcode
+# Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
@@ -88,5 +88,3 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
-
-Keys.plist

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Xcode
+t# Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
@@ -88,3 +88,5 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+Keys.plist

--- a/Suko.xcodeproj/project.pbxproj
+++ b/Suko.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		536AFC4D28875E6E00B01F95 /* SUKEventDetailsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 536AFC4C28875E6E00B01F95 /* SUKEventDetailsViewController.m */; };
 		536AFC4F2887602500B01F95 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 536AFC4E2887602500B01F95 /* CoreLocation.framework */; };
 		536AFC512887622300B01F95 /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 536AFC502887622300B01F95 /* Contacts.framework */; };
+		53785C2A2888A26B0047F5DC /* SUKQuizViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 53785C292888A26B0047F5DC /* SUKQuizViewController.m */; };
 		5397F5E8286B676800E9D894 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 5397F5E7286B676800E9D894 /* AppDelegate.m */; };
 		5397F5EB286B676800E9D894 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 5397F5EA286B676800E9D894 /* SceneDelegate.m */; };
 		5397F5F1286B676800E9D894 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5397F5EF286B676800E9D894 /* Main.storyboard */; };
@@ -87,6 +88,8 @@
 		536AFC4C28875E6E00B01F95 /* SUKEventDetailsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SUKEventDetailsViewController.m; sourceTree = "<group>"; };
 		536AFC4E2887602500B01F95 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		536AFC502887622300B01F95 /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = System/Library/Frameworks/Contacts.framework; sourceTree = SDKROOT; };
+		53785C282888A26B0047F5DC /* SUKQuizViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SUKQuizViewController.h; sourceTree = "<group>"; };
+		53785C292888A26B0047F5DC /* SUKQuizViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SUKQuizViewController.m; sourceTree = "<group>"; };
 		5397F5E3286B676800E9D894 /* Suko.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Suko.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5397F5E6286B676800E9D894 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		5397F5E7286B676800E9D894 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -226,6 +229,8 @@
 				53ABF51E28872F9D0015F1DB /* SUKBrowseEventViewController.m */,
 				536AFC4B28875E6E00B01F95 /* SUKEventDetailsViewController.h */,
 				536AFC4C28875E6E00B01F95 /* SUKEventDetailsViewController.m */,
+				53785C282888A26B0047F5DC /* SUKQuizViewController.h */,
+				53785C292888A26B0047F5DC /* SUKQuizViewController.m */,
 			);
 			path = "View Controller";
 			sourceTree = "<group>";
@@ -563,6 +568,7 @@
 				53B330262877A31E0013F404 /* SUKAnimeListTableViewCell.m in Sources */,
 				53A97520287DF9B400D163BF /* SUKProfileViewController.m in Sources */,
 				53E0D7922878FAD900CFCF91 /* SUKLibraryTableViewCell.m in Sources */,
+				53785C2A2888A26B0047F5DC /* SUKQuizViewController.m in Sources */,
 				53E1CE022881C8D400186E36 /* SUKEvent.m in Sources */,
 				5302D388287F7A280009018D /* SUKUserMapViewController.m in Sources */,
 				5397F5EB286B676800E9D894 /* SceneDelegate.m in Sources */,

--- a/Suko.xcodeproj/project.pbxproj
+++ b/Suko.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		53A97523287DFCF900D163BF /* SUKEditProfileViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 53A97522287DFCF900D163BF /* SUKEditProfileViewController.m */; };
 		53ABF51A288717F00015F1DB /* SUKChooseEventLocationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 53ABF519288717F00015F1DB /* SUKChooseEventLocationViewController.m */; };
 		53ABF51F28872F9D0015F1DB /* SUKBrowseEventViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 53ABF51E28872F9D0015F1DB /* SUKBrowseEventViewController.m */; };
-		53ABF522288746DB0015F1DB /* SUKEventTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 53ABF521288746DB0015F1DB /* SUKEventTableViewCell.m */; };
+		53ABF522288746DB0015F1DB /* SUKBrowseEventTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 53ABF521288746DB0015F1DB /* SUKBrowseEventTableViewCell.m */; };
 		53B3302028779B070013F404 /* SUKAnimeListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 53B3301F28779B070013F404 /* SUKAnimeListViewController.m */; };
 		53B330262877A31E0013F404 /* SUKAnimeListTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 53B330252877A31E0013F404 /* SUKAnimeListTableViewCell.m */; };
 		53C81C8B2885D46500092A46 /* SUKFollow.m in Sources */ = {isa = PBXBuildFile; fileRef = 53C81C8A2885D46500092A46 /* SUKFollow.m */; };
@@ -107,8 +107,8 @@
 		53ABF519288717F00015F1DB /* SUKChooseEventLocationViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SUKChooseEventLocationViewController.m; sourceTree = "<group>"; };
 		53ABF51D28872F9D0015F1DB /* SUKBrowseEventViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SUKBrowseEventViewController.h; sourceTree = "<group>"; };
 		53ABF51E28872F9D0015F1DB /* SUKBrowseEventViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SUKBrowseEventViewController.m; sourceTree = "<group>"; };
-		53ABF520288746DB0015F1DB /* SUKEventTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SUKEventTableViewCell.h; sourceTree = "<group>"; };
-		53ABF521288746DB0015F1DB /* SUKEventTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SUKEventTableViewCell.m; sourceTree = "<group>"; };
+		53ABF520288746DB0015F1DB /* SUKBrowseEventTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SUKBrowseEventTableViewCell.h; sourceTree = "<group>"; };
+		53ABF521288746DB0015F1DB /* SUKBrowseEventTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SUKBrowseEventTableViewCell.m; sourceTree = "<group>"; };
 		53B3301E28779B070013F404 /* SUKAnimeListViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SUKAnimeListViewController.h; sourceTree = "<group>"; };
 		53B3301F28779B070013F404 /* SUKAnimeListViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SUKAnimeListViewController.m; sourceTree = "<group>"; };
 		53B330242877A31E0013F404 /* SUKAnimeListTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SUKAnimeListTableViewCell.h; sourceTree = "<group>"; };
@@ -176,8 +176,8 @@
 				53B330252877A31E0013F404 /* SUKAnimeListTableViewCell.m */,
 				53E0D7902878FAD900CFCF91 /* SUKLibraryTableViewCell.h */,
 				53E0D7912878FAD900CFCF91 /* SUKLibraryTableViewCell.m */,
-				53ABF520288746DB0015F1DB /* SUKEventTableViewCell.h */,
-				53ABF521288746DB0015F1DB /* SUKEventTableViewCell.m */,
+				53ABF520288746DB0015F1DB /* SUKBrowseEventTableViewCell.h */,
+				53ABF521288746DB0015F1DB /* SUKBrowseEventTableViewCell.m */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -543,7 +543,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				53ABF522288746DB0015F1DB /* SUKEventTableViewCell.m in Sources */,
+				53ABF522288746DB0015F1DB /* SUKBrowseEventTableViewCell.m in Sources */,
 				53A97523287DFCF900D163BF /* SUKEditProfileViewController.m in Sources */,
 				536AFC4D28875E6E00B01F95 /* SUKEventDetailsViewController.m in Sources */,
 				53CCA6EA28808E5900B217F5 /* SUKNotCurrentUserProfileViewController.m in Sources */,

--- a/Suko/API/SUKAPIManager.h
+++ b/Suko/API/SUKAPIManager.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SUKAPIManager : NSObject
 + (instancetype)shared;
+- (void)cancelAllRequests;
 - (void)fetchAnimeWithID:(NSNumber *) malID completion:(void(^)(SUKAnime* anime, NSError *error))completion;
 - (void)fetchTopAnimeList:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion;
 - (void)fetchAnimeListWithGenre:(NSString *) genre completion:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion;

--- a/Suko/API/SUKAPIManager.h
+++ b/Suko/API/SUKAPIManager.h
@@ -12,11 +12,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SUKAPIManager : NSObject
 + (instancetype)shared;
-- (void)fetchSpecificAnimeByID:(NSNumber *) malID completion:(void(^)(SUKAnime* anime, NSError *error))completion;
-- (void)fetchTopAnime:(void(^)(NSArray<SUKAnime*> *arrofAnimeObjs, NSError *error))completion;
-- (void)fetchGenreAnime:(NSString *) genre completion:(void(^)(NSArray<SUKAnime*> *arrofAnimeObjs, NSError *error))completion;
-- (void)fetchGenreList:(void(^)(NSArray<NSDictionary*> *genres, NSError *error))completion;
-- (void)fetchAnimeSearchBySearchQuery:(NSString *) query completion:(void(^)(NSArray<SUKAnime*> *arrofAnimeObjs, NSError *error))completion;
+- (void)fetchAnimeWithID:(NSNumber *) malID completion:(void(^)(SUKAnime* anime, NSError *error))completion;
+- (void)fetchTopAnimeList:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion;
+- (void)fetchAnimeListWithGenre:(NSString *) genre completion:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion;
+- (void)fetchGenreList:(void(^)(NSArray<NSDictionary *> *genres, NSError *error))completion;
+- (void)fetchAnimeSearchWithSearchQuery:(NSString *) query completion:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion;
 
 @end
 

--- a/Suko/API/SUKAPIManager.h
+++ b/Suko/API/SUKAPIManager.h
@@ -13,10 +13,10 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SUKAPIManager : NSObject
 + (instancetype)shared;
 - (void)fetchSpecificAnimeByID:(NSNumber *) malID completion:(void(^)(SUKAnime* anime, NSError *error))completion;
-- (void)fetchTopAnime:(void(^)(NSArray *arrofAnimeObjs, NSError *error))completion;
-- (void)fetchGenreAnime:(NSString *) genre completion:(void(^)(NSArray *arrofAnimeObjs, NSError *error))completion;
-- (void)fetchGenreList:(void(^)(NSArray *genres, NSError *error))completion;
-- (void)fetchAnimeSearchBySearchQuery:(NSString *) query completion:(void(^)(NSArray *arrofAnimeObjs, NSError *error))completion;
+- (void)fetchTopAnime:(void(^)(NSArray<SUKAnime*> *arrofAnimeObjs, NSError *error))completion;
+- (void)fetchGenreAnime:(NSString *) genre completion:(void(^)(NSArray<SUKAnime*> *arrofAnimeObjs, NSError *error))completion;
+- (void)fetchGenreList:(void(^)(NSArray<NSDictionary*> *genres, NSError *error))completion;
+- (void)fetchAnimeSearchBySearchQuery:(NSString *) query completion:(void(^)(NSArray<SUKAnime*> *arrofAnimeObjs, NSError *error))completion;
 
 @end
 

--- a/Suko/API/SUKAPIManager.h
+++ b/Suko/API/SUKAPIManager.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)fetchAnimeWithID:(NSNumber *) malID completion:(void(^)(SUKAnime* anime, NSError *error))completion;
 - (void)fetchTopAnimeList:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion;
 - (void)fetchAnimeListWithGenre:(NSString *) genre completion:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion;
-- (void)fetchGenreList:(void(^)(NSArray<NSDictionary *> *genres, NSError *error))completion;
+- (void)fetchAnimeGenreList:(void(^)(NSArray<NSDictionary *> *genres, NSError *error))completion;
 - (void)fetchAnimeSearchWithSearchQuery:(NSString *) query completion:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion;
 
 @end

--- a/Suko/API/SUKAPIManager.m
+++ b/Suko/API/SUKAPIManager.m
@@ -32,7 +32,7 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
     self.manager = [AFHTTPSessionManager manager];
     
     AFJSONResponseSerializer *serializer = [AFJSONResponseSerializer serializer];
-    [serializer setRemovesKeysWithNullValues:YES]; //turn NULL to nil
+    [serializer setRemovesKeysWithNullValues:YES]; // Turn NULL to nil
     [self.manager setResponseSerializer:serializer];
     
     return self;

--- a/Suko/API/SUKAPIManager.m
+++ b/Suko/API/SUKAPIManager.m
@@ -104,7 +104,7 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
         // Currently, Jikan API returns data that has been deleted by MyAnimeList already
         // Ex. If you search "One Piece," you will receive 3 One Piece's, and only one of them has a valid URL and with information filled
         // I noticed that invalid data has a popularity field of 0, so this is my workaround for now.
-        NSMutableArray<NSDictionary *> *arrOfAnimeDictionariesMutable = [NSMutableArray array];
+        NSMutableArray<NSDictionary *> *arrOfAnimeDictionariesMutable = [NSMutableArray new];
         for(NSDictionary *animeDictionary in arrOfAnimeDictionaries) {
             if([animeDictionary[@"popularity"] intValue] != 0){
                 [arrOfAnimeDictionariesMutable addObject:animeDictionary];

--- a/Suko/API/SUKAPIManager.m
+++ b/Suko/API/SUKAPIManager.m
@@ -38,87 +38,76 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
     return self;
 }
 
-- (void)fetchSpecificAnimeByID:(NSNumber *) malID completion:(void(^)(SUKAnime* anime, NSError *error))completion {
+- (void)fetchAnimeWithID:(NSNumber *) malID completion:(void(^)(SUKAnime* anime, NSError *error))completion {
     NSString *malIDString = [NSString stringWithFormat:@"%d",[malID intValue]];
     NSDictionary *params = @{@"id": malID};
-    NSString *fullURLString = [baseURLString
-                               stringByAppendingString:[@"/anime/"
-                                                        stringByAppendingString:[malIDString stringByAppendingString:@"/full"]]];
+    NSString *fullURLString = [baseURLString stringByAppendingString:[@"/anime/" stringByAppendingString:[malIDString stringByAppendingString:@"/full"]]];
+    
     [self.manager GET:fullURLString parameters:params progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
-        NSDictionary *animeInfoDict = dataDictionary[@"data"]; // array indices each contains a dictionary with info on an anime
-        SUKAnime *animeObj = [SUKAnime animeWithDictionary:animeInfoDict]; // array indices each contain an Anime object
-        
+        SUKAnime *animeObj = [SUKAnime animeWithDictionary:dataDictionary[@"data"]];
         completion(animeObj, nil);
     } failure:^(NSURLSessionTask *operation, NSError *error) {
         NSLog(@"Error: %@", error);
     }];
 }
 
-- (void)fetchGenreAnime:(NSString *) genre completion:(void(^)(NSArray<SUKAnime*> *arrofAnimeObjs, NSError *error))completion {
+- (void)fetchAnimeListWithGenre:(NSString *) genre completion:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion {
     NSDictionary *params = @{@"type": @"tv", @"limit": knumOfAnimeDisplayedPerRow, @"order_by": @"score", @"sort": @"desc", @"genres":genre};
     NSString *fullURLString = [baseURLString stringByAppendingString:@"/anime"];
     
     [self.manager GET:fullURLString parameters:params progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
-        NSArray *arrOfAnimeDictionaries = dataDictionary[@"data"]; // array indices each contains a dictionary with info on an anime
-        NSArray<SUKAnime*> *arrOfAnimeObjs = [SUKAnime animesWithArrayOfDictionaries:arrOfAnimeDictionaries]; // array indices each contain an Anime object
-        
+        NSArray<SUKAnime *> *arrOfAnimeObjs = [SUKAnime animesWithArrayOfDictionaries:dataDictionary[@"data"]];
         completion(arrOfAnimeObjs, nil);
     } failure:^(NSURLSessionTask *operation, NSError *error) {
         NSLog(@"Error: %@", error);
     }];
 }
 
-- (void)fetchTopAnime:(void(^)(NSArray<SUKAnime*> *arrofAnimeObjs, NSError *error))completion {
+- (void)fetchTopAnimeList:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion {
     NSDictionary *params = @{@"type": @"tv", @"limit": knumOfAnimeDisplayedPerRow};
     NSString *fullURLString = [baseURLString stringByAppendingString:@"/top/anime"];
     
     [self.manager GET:fullURLString parameters:params progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
-        NSArray<NSDictionary*> *arrOfAnimeDictionaries = dataDictionary[@"data"]; // array indices each contains a dictionary with info on an anime
-        NSArray<SUKAnime*> *arrOfAnimeObjs = [SUKAnime animesWithArrayOfDictionaries:arrOfAnimeDictionaries]; // array indices each contain an Anime object
-        
+        NSArray<SUKAnime *> *arrOfAnimeObjs = [SUKAnime animesWithArrayOfDictionaries:dataDictionary[@"data"]];
         completion(arrOfAnimeObjs, nil);
     } failure:^(NSURLSessionTask *operation, NSError *error) {
         NSLog(@"Error: %@", error);
     }];
 }
 
-- (void)fetchGenreList:(void(^)(NSArray<NSDictionary*> *genres, NSError *error))completion {
+- (void)fetchGenreList:(void(^)(NSArray<NSDictionary *> *genres, NSError *error))completion {
     NSString *fullURLString = [baseURLString stringByAppendingString:@"/genres/anime"];
     
     [self.manager GET:fullURLString parameters:nil progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
-        NSArray<NSDictionary*> *genreList = dataDictionary[@"data"];
-        completion(genreList, nil);
+        completion(dataDictionary[@"data"], nil);
     } failure:^(NSURLSessionTask *operation, NSError *error) {
         NSLog(@"Error: %@", error);
     }];
 }
 
-- (void)fetchAnimeSearchBySearchQuery:(NSString *) query completion:(void(^)(NSArray<SUKAnime*> *arrofAnimeObjs, NSError *error))completion {
+- (void)fetchAnimeSearchWithSearchQuery:(NSString *) query completion:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion {
     NSDictionary *params = @{@"q": query, @"type": @"tv", @"sort": @"desc"};
     NSString *fullURLString = [baseURLString stringByAppendingString:@"/anime"];
     
     [self.manager GET:fullURLString parameters:params progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
-        NSArray<NSDictionary*> *arrOfAnimeDictionaries = dataDictionary[@"data"]; // array indices each contains a dictionary with info on an anime
+        NSArray<NSDictionary *> *arrOfAnimeDictionaries = dataDictionary[@"data"];
         
         // Currently, Jikan API returns data that has been deleted by MyAnimeList already
         // Ex. If you search "One Piece," you will receive 3 One Piece's, and only one of them has a valid URL and with information filled
         // I noticed that invalid data has a popularity field of 0, so this is my workaround for now.
-        NSMutableArray<NSDictionary*> *arrOfAnimeDictionariesMutable = [NSMutableArray array];
+        NSMutableArray<NSDictionary *> *arrOfAnimeDictionariesMutable = [NSMutableArray array];
         for(NSDictionary *animeDictionary in arrOfAnimeDictionaries) {
             if([animeDictionary[@"popularity"] intValue] != 0){
                 [arrOfAnimeDictionariesMutable addObject:animeDictionary];
             }
         }
-        
-        arrOfAnimeDictionaries = (NSArray*)arrOfAnimeDictionariesMutable;
-        
-        NSArray<SUKAnime*> *arrOfAnimeObjs = [SUKAnime animesWithArrayOfDictionaries:arrOfAnimeDictionaries]; // array indices each contain an Anime object
-        
+                
+        NSArray<SUKAnime *> *arrOfAnimeObjs = [SUKAnime animesWithArrayOfDictionaries:[arrOfAnimeDictionariesMutable copy]];
         completion(arrOfAnimeObjs, nil);
     } failure:^(NSURLSessionTask *operation, NSError *error) {
         NSLog(@"Error: %@", error);

--- a/Suko/API/SUKAPIManager.m
+++ b/Suko/API/SUKAPIManager.m
@@ -9,7 +9,8 @@
 #import "AFNetworking.h"
 #import "SUKAnime.h"
 
-static NSString * const baseURLString = @"https://api.jikan.moe/v4";
+static NSString * const baseAnimeAPIURLString = @"https://api.jikan.moe/v4";
+static NSString * const baseMovieAPIURLString = @"https://api.themoviedb.org/3/";
 
 @interface SUKAPIManager ()
 @property (strong, nonatomic) AFHTTPSessionManager *manager;
@@ -45,7 +46,7 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
 - (void)fetchAnimeWithID:(NSNumber *) malID completion:(void(^)(SUKAnime* anime, NSError *error))completion {
     NSString *malIDString = [NSString stringWithFormat:@"%d",[malID intValue]];
     NSDictionary *params = @{@"id": malID};
-    NSString *fullURLString = [baseURLString stringByAppendingString:[@"/anime/" stringByAppendingString:[malIDString stringByAppendingString:@"/full"]]];
+    NSString *fullURLString = [baseAnimeAPIURLString stringByAppendingString:[@"/anime/" stringByAppendingString:[malIDString stringByAppendingString:@"/full"]]];
     
     [self.manager GET:fullURLString parameters:params progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
@@ -58,7 +59,7 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
 
 - (void)fetchAnimeListWithGenre:(NSString *) genre completion:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion {
     NSDictionary *params = @{@"type": @"tv", @"limit": knumOfAnimeDisplayedPerRow, @"order_by": @"score", @"sort": @"desc", @"genres":genre};
-    NSString *fullURLString = [baseURLString stringByAppendingString:@"/anime"];
+    NSString *fullURLString = [baseAnimeAPIURLString stringByAppendingString:@"/anime"];
     
     [self.manager GET:fullURLString parameters:params progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
@@ -71,7 +72,7 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
 
 - (void)fetchTopAnimeList:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion {
     NSDictionary *params = @{@"type": @"tv", @"limit": knumOfAnimeDisplayedPerRow};
-    NSString *fullURLString = [baseURLString stringByAppendingString:@"/top/anime"];
+    NSString *fullURLString = [baseAnimeAPIURLString stringByAppendingString:@"/top/anime"];
     
     [self.manager GET:fullURLString parameters:params progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
@@ -82,8 +83,8 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
     }];
 }
 
-- (void)fetchGenreList:(void(^)(NSArray<NSDictionary *> *genres, NSError *error))completion {
-    NSString *fullURLString = [baseURLString stringByAppendingString:@"/genres/anime"];
+- (void)fetchAnimeGenreList:(void(^)(NSArray<NSDictionary *> *animeGenres, NSError *error))completion {
+    NSString *fullURLString = [baseAnimeAPIURLString stringByAppendingString:@"/genres/anime"];
     
     [self.manager GET:fullURLString parameters:nil progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
@@ -95,7 +96,7 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
 
 - (void)fetchAnimeSearchWithSearchQuery:(NSString *) query completion:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion {
     NSDictionary *params = @{@"q": query, @"type": @"tv", @"sort": @"desc"};
-    NSString *fullURLString = [baseURLString stringByAppendingString:@"/anime"];
+    NSString *fullURLString = [baseAnimeAPIURLString stringByAppendingString:@"/anime"];
     
     [self.manager GET:fullURLString parameters:params progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
@@ -116,6 +117,10 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
     } failure:^(NSURLSessionTask *operation, NSError *error) {
         NSLog(@"Error: %@", error);
     }];
+}
+
+- (void)fetchMovieGenreList:(void(^)(NSArray<NSDictionary *> *movieGenres, NSError *error))completion {
+    
 }
 
 @end

--- a/Suko/API/SUKAPIManager.m
+++ b/Suko/API/SUKAPIManager.m
@@ -22,7 +22,7 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
     static SUKAPIManager *sharedManager = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        sharedManager = [[self alloc] init];
+        sharedManager = [self new];
     });
     return sharedManager;
 }

--- a/Suko/API/SUKAPIManager.m
+++ b/Suko/API/SUKAPIManager.m
@@ -55,14 +55,14 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
     }];
 }
 
-- (void)fetchGenreAnime:(NSString *) genre completion:(void(^)(NSArray *arrofAnimeObjs, NSError *error))completion {
+- (void)fetchGenreAnime:(NSString *) genre completion:(void(^)(NSArray<SUKAnime*> *arrofAnimeObjs, NSError *error))completion {
     NSDictionary *params = @{@"type": @"tv", @"limit": knumOfAnimeDisplayedPerRow, @"order_by": @"score", @"sort": @"desc", @"genres":genre};
     NSString *fullURLString = [baseURLString stringByAppendingString:@"/anime"];
     
     [self.manager GET:fullURLString parameters:params progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
         NSArray *arrOfAnimeDictionaries = dataDictionary[@"data"]; // array indices each contains a dictionary with info on an anime
-        NSArray *arrOfAnimeObjs = [SUKAnime animesWithArrayOfDictionaries:arrOfAnimeDictionaries]; // array indices each contain an Anime object
+        NSArray<SUKAnime*> *arrOfAnimeObjs = [SUKAnime animesWithArrayOfDictionaries:arrOfAnimeDictionaries]; // array indices each contain an Anime object
         
         completion(arrOfAnimeObjs, nil);
     } failure:^(NSURLSessionTask *operation, NSError *error) {
@@ -70,14 +70,14 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
     }];
 }
 
-- (void)fetchTopAnime:(void(^)(NSArray *arrofAnimeObjs, NSError *error))completion {
+- (void)fetchTopAnime:(void(^)(NSArray<SUKAnime*> *arrofAnimeObjs, NSError *error))completion {
     NSDictionary *params = @{@"type": @"tv", @"limit": knumOfAnimeDisplayedPerRow};
     NSString *fullURLString = [baseURLString stringByAppendingString:@"/top/anime"];
     
     [self.manager GET:fullURLString parameters:params progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
-        NSArray *arrOfAnimeDictionaries = dataDictionary[@"data"]; // array indices each contains a dictionary with info on an anime
-        NSArray *arrOfAnimeObjs = [SUKAnime animesWithArrayOfDictionaries:arrOfAnimeDictionaries]; // array indices each contain an Anime object
+        NSArray<NSDictionary*> *arrOfAnimeDictionaries = dataDictionary[@"data"]; // array indices each contains a dictionary with info on an anime
+        NSArray<SUKAnime*> *arrOfAnimeObjs = [SUKAnime animesWithArrayOfDictionaries:arrOfAnimeDictionaries]; // array indices each contain an Anime object
         
         completion(arrOfAnimeObjs, nil);
     } failure:^(NSURLSessionTask *operation, NSError *error) {
@@ -85,19 +85,19 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
     }];
 }
 
-- (void)fetchGenreList:(void(^)(NSArray *genres, NSError *error))completion {
+- (void)fetchGenreList:(void(^)(NSArray<NSDictionary*> *genres, NSError *error))completion {
     NSString *fullURLString = [baseURLString stringByAppendingString:@"/genres/anime"];
     
     [self.manager GET:fullURLString parameters:nil progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
-        NSArray *genreList = dataDictionary[@"data"];
+        NSArray<NSDictionary*> *genreList = dataDictionary[@"data"];
         completion(genreList, nil);
     } failure:^(NSURLSessionTask *operation, NSError *error) {
         NSLog(@"Error: %@", error);
     }];
 }
 
-- (void)fetchAnimeSearchBySearchQuery:(NSString *) query completion:(void(^)(NSArray *arrofAnimeObjs, NSError *error))completion {
+- (void)fetchAnimeSearchBySearchQuery:(NSString *) query completion:(void(^)(NSArray<SUKAnime*> *arrofAnimeObjs, NSError *error))completion {
     NSDictionary *params = @{@"q": query, @"type": @"tv", @"sort": @"desc"};
     NSString *fullURLString = [baseURLString stringByAppendingString:@"/anime"];
     
@@ -117,7 +117,7 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
         
         arrOfAnimeDictionaries = (NSArray*)arrOfAnimeDictionariesMutable;
         
-        NSArray *arrOfAnimeObjs = [SUKAnime animesWithArrayOfDictionaries:arrOfAnimeDictionaries]; // array indices each contain an Anime object
+        NSArray<SUKAnime*> *arrOfAnimeObjs = [SUKAnime animesWithArrayOfDictionaries:arrOfAnimeDictionaries]; // array indices each contain an Anime object
         
         completion(arrOfAnimeObjs, nil);
     } failure:^(NSURLSessionTask *operation, NSError *error) {

--- a/Suko/API/SUKAPIManager.m
+++ b/Suko/API/SUKAPIManager.m
@@ -38,6 +38,10 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
     return self;
 }
 
+- (void)cancelAllRequests {
+    [self.manager.tasks makeObjectsPerformSelector:@selector(cancel)];
+}
+
 - (void)fetchAnimeWithID:(NSNumber *) malID completion:(void(^)(SUKAnime* anime, NSError *error))completion {
     NSString *malIDString = [NSString stringWithFormat:@"%d",[malID intValue]];
     NSDictionary *params = @{@"id": malID};

--- a/Suko/API/SUKAPIManager.m
+++ b/Suko/API/SUKAPIManager.m
@@ -9,8 +9,7 @@
 #import "AFNetworking.h"
 #import "SUKAnime.h"
 
-static NSString * const baseAnimeAPIURLString = @"https://api.jikan.moe/v4";
-static NSString * const baseMovieAPIURLString = @"https://api.themoviedb.org/3/";
+static NSString * const baseAnimeURLString = @"https://api.jikan.moe/v4";
 
 @interface SUKAPIManager ()
 @property (strong, nonatomic) AFHTTPSessionManager *manager;
@@ -46,7 +45,7 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
 - (void)fetchAnimeWithID:(NSNumber *) malID completion:(void(^)(SUKAnime* anime, NSError *error))completion {
     NSString *malIDString = [NSString stringWithFormat:@"%d",[malID intValue]];
     NSDictionary *params = @{@"id": malID};
-    NSString *fullURLString = [baseAnimeAPIURLString stringByAppendingString:[@"/anime/" stringByAppendingString:[malIDString stringByAppendingString:@"/full"]]];
+    NSString *fullURLString = [baseAnimeURLString stringByAppendingString:[@"/anime/" stringByAppendingString:[malIDString stringByAppendingString:@"/full"]]];
     
     [self.manager GET:fullURLString parameters:params progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
@@ -59,7 +58,7 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
 
 - (void)fetchAnimeListWithGenre:(NSString *) genre completion:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion {
     NSDictionary *params = @{@"type": @"tv", @"limit": knumOfAnimeDisplayedPerRow, @"order_by": @"score", @"sort": @"desc", @"genres":genre};
-    NSString *fullURLString = [baseAnimeAPIURLString stringByAppendingString:@"/anime"];
+    NSString *fullURLString = [baseAnimeURLString stringByAppendingString:@"/anime"];
     
     [self.manager GET:fullURLString parameters:params progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
@@ -72,7 +71,7 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
 
 - (void)fetchTopAnimeList:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion {
     NSDictionary *params = @{@"type": @"tv", @"limit": knumOfAnimeDisplayedPerRow};
-    NSString *fullURLString = [baseAnimeAPIURLString stringByAppendingString:@"/top/anime"];
+    NSString *fullURLString = [baseAnimeURLString stringByAppendingString:@"/top/anime"];
     
     [self.manager GET:fullURLString parameters:params progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
@@ -83,8 +82,8 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
     }];
 }
 
-- (void)fetchAnimeGenreList:(void(^)(NSArray<NSDictionary *> *animeGenres, NSError *error))completion {
-    NSString *fullURLString = [baseAnimeAPIURLString stringByAppendingString:@"/genres/anime"];
+- (void)fetchAnimeGenreList:(void(^)(NSArray<NSDictionary *> *genres, NSError *error))completion {
+    NSString *fullURLString = [baseAnimeURLString stringByAppendingString:@"/genres/anime"];
     
     [self.manager GET:fullURLString parameters:nil progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
@@ -96,7 +95,7 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
 
 - (void)fetchAnimeSearchWithSearchQuery:(NSString *) query completion:(void(^)(NSArray<SUKAnime *> *arrofAnime, NSError *error))completion {
     NSDictionary *params = @{@"q": query, @"type": @"tv", @"sort": @"desc"};
-    NSString *fullURLString = [baseAnimeAPIURLString stringByAppendingString:@"/anime"];
+    NSString *fullURLString = [baseAnimeURLString stringByAppendingString:@"/anime"];
     
     [self.manager GET:fullURLString parameters:params progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSDictionary *dataDictionary = responseObject;
@@ -117,10 +116,6 @@ const NSNumber *knumOfAnimeDisplayedPerRow = @10;
     } failure:^(NSURLSessionTask *operation, NSError *error) {
         NSLog(@"Error: %@", error);
     }];
-}
-
-- (void)fetchMovieGenreList:(void(^)(NSArray<NSDictionary *> *movieGenres, NSError *error))completion {
-    
 }
 
 @end

--- a/Suko/Base.lproj/Main.storyboard
+++ b/Suko/Base.lproj/Main.storyboard
@@ -337,7 +337,7 @@
                                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                     <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="GmA-lZ-2kB">
                                                         <size key="itemSize" width="185" height="252"/>
-                                                        <size key="estimatedItemSize" width="185" height="277"/>
+                                                        <size key="estimatedItemSize" width="185" height="252"/>
                                                         <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                                         <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                                         <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
@@ -368,6 +368,7 @@
                                                                 <constraints>
                                                                     <constraint firstItem="CWS-86-omw" firstAttribute="top" secondItem="GLQ-Dp-I2R" secondAttribute="top" id="Np9-ka-mPj"/>
                                                                     <constraint firstAttribute="trailing" secondItem="CWS-86-omw" secondAttribute="trailing" id="RGn-Lq-mqp"/>
+                                                                    <constraint firstAttribute="bottom" secondItem="sZj-uM-5lc" secondAttribute="bottom" constant="8" id="V5Y-1E-jOX"/>
                                                                     <constraint firstItem="sZj-uM-5lc" firstAttribute="leading" secondItem="GLQ-Dp-I2R" secondAttribute="leading" constant="8" id="clp-bq-sfd"/>
                                                                     <constraint firstItem="CWS-86-omw" firstAttribute="leading" secondItem="GLQ-Dp-I2R" secondAttribute="leading" id="kVE-mk-FcY"/>
                                                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="sZj-uM-5lc" secondAttribute="trailing" constant="8" id="naE-xi-qXI"/>
@@ -412,8 +413,10 @@
                                 </prototypes>
                             </tableView>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" id="Y0o-p9-vyC">
-                                <rect key="frame" x="0.0" y="517" width="414" height="39"/>
+                                <rect key="frame" x="183" y="526" width="39" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="color" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </activityIndicatorView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
@@ -499,8 +502,10 @@
                                 </prototypes>
                             </tableView>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" id="6x9-O9-7d8">
-                                <rect key="frame" x="0.0" y="426" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="426" width="39" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="color" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </activityIndicatorView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="IvK-Z4-S0e"/>
@@ -1132,8 +1137,10 @@
                                 </prototypes>
                             </tableView>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" id="M0l-T9-9PQ">
-                                <rect key="frame" x="0.0" y="426" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="426" width="39" height="39"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="color" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </activityIndicatorView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="kRc-2x-ysI"/>
@@ -1559,7 +1566,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="rpV-XQ-NWa"/>
+        <segue reference="DYo-a4-zd2"/>
         <segue reference="wz9-h9-cFl"/>
         <segue reference="4vs-CO-2P5"/>
     </inferredMetricsTieBreakers>

--- a/Suko/Base.lproj/Main.storyboard
+++ b/Suko/Base.lproj/Main.storyboard
@@ -1551,7 +1551,7 @@
     <inferredMetricsTieBreakers>
         <segue reference="rpV-XQ-NWa"/>
         <segue reference="wz9-h9-cFl"/>
-        <segue reference="tAG-hY-s6j"/>
+        <segue reference="4vs-CO-2P5"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="LoginScreen" width="1944.5" height="2916.5"/>

--- a/Suko/Base.lproj/Main.storyboard
+++ b/Suko/Base.lproj/Main.storyboard
@@ -1102,7 +1102,7 @@
                                         <connections>
                                             <outlet property="dateLabel" destination="uV8-LG-DKP" id="1iT-GL-0Ig"/>
                                             <outlet property="eventNameLabel" destination="zNF-RK-n0r" id="VkP-nR-6DI"/>
-                                            <outlet property="userProfileImage" destination="1Xx-vi-fAy" id="9Vk-Pq-chX"/>
+                                            <outlet property="profileImageView" destination="1Xx-vi-fAy" id="9Vk-Pq-chX"/>
                                             <outlet property="usernameLabel" destination="xtp-VG-za1" id="lKV-g1-j3z"/>
                                             <segue destination="oIa-nP-6pt" kind="show" identifier="BrowseEventsToEventDetailsSegue" id="Ny8-eA-9as"/>
                                         </connections>
@@ -1457,8 +1457,8 @@
                         <outlet property="dateLabel" destination="sjt-Wp-IyL" id="D0D-wo-J9c"/>
                         <outlet property="decriptionLabel" destination="2ut-5u-oQ8" id="QEN-BO-dBG"/>
                         <outlet property="eventNameLabel" destination="SAG-ES-okg" id="tFv-G4-eK9"/>
+                        <outlet property="profileImageView" destination="YYc-p2-EMY" id="Ksy-9R-dBp"/>
                         <outlet property="registerButton" destination="0TZ-Zo-6mI" id="Ilc-6W-idO"/>
-                        <outlet property="userProfileImage" destination="YYc-p2-EMY" id="Ksy-9R-dBp"/>
                         <outlet property="usernameLabel" destination="ngn-le-IGH" id="t5g-eD-LC0"/>
                     </connections>
                 </viewController>

--- a/Suko/Base.lproj/Main.storyboard
+++ b/Suko/Base.lproj/Main.storyboard
@@ -430,7 +430,7 @@
                         <outlet property="searchBar" destination="d03-rZ-Tgk" id="Dhd-UU-09r"/>
                         <outlet property="spinner" destination="Y0o-p9-vyC" id="iTX-bk-Ms5"/>
                         <outlet property="tableView" destination="IqB-dM-fLm" id="aOy-Kr-bFz"/>
-                        <segue destination="OiV-xg-5bj" kind="show" identifier="HomeToDetailsSegue" id="4vs-CO-2P5"/>
+                        <segue destination="OiV-xg-5bj" kind="show" identifier="HomeToListSegue" id="4vs-CO-2P5"/>
                         <segue destination="7E0-o4-0mw" kind="show" identifier="CollectionToDetailsSegue" id="wz9-h9-cFl"/>
                     </connections>
                 </viewController>
@@ -1549,9 +1549,9 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="rpV-XQ-NWa"/>
+        <segue reference="DYo-a4-zd2"/>
         <segue reference="wz9-h9-cFl"/>
-        <segue reference="tAG-hY-s6j"/>
+        <segue reference="EZ4-Jx-OHr"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="LoginScreen" width="1944.5" height="2916.5"/>

--- a/Suko/Base.lproj/Main.storyboard
+++ b/Suko/Base.lproj/Main.storyboard
@@ -1041,9 +1041,31 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="k0i-jF-q1u">
                                 <rect key="frame" x="0.0" y="88" width="414" height="725"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <view key="tableHeaderView" contentMode="scaleToFill" id="9UN-Ip-eNX">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="55"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <subviews>
+                                        <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="T80-LS-hV3">
+                                            <rect key="frame" x="0.0" y="12" width="414" height="32"/>
+                                            <segments>
+                                                <segment title="Discover"/>
+                                                <segment title="Registered"/>
+                                            </segments>
+                                            <connections>
+                                                <action selector="segmentChanged:" destination="SCL-JL-gSG" eventType="valueChanged" id="hQc-r6-1He"/>
+                                            </connections>
+                                        </segmentedControl>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                    <constraints>
+                                        <constraint firstItem="T80-LS-hV3" firstAttribute="leading" secondItem="9UN-Ip-eNX" secondAttribute="leading" id="0UB-Km-P8J"/>
+                                        <constraint firstItem="T80-LS-hV3" firstAttribute="centerY" secondItem="9UN-Ip-eNX" secondAttribute="centerY" id="2gj-Ub-cYh"/>
+                                        <constraint firstAttribute="trailing" secondItem="T80-LS-hV3" secondAttribute="trailing" id="cG5-gg-FDG"/>
+                                    </constraints>
+                                </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SUKEventTableViewCell" rowHeight="128" id="ijO-jL-1gA" customClass="SUKEventTableViewCell">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="128"/>
+                                        <rect key="frame" x="0.0" y="99.5" width="414" height="128"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ijO-jL-1gA" id="7YT-ny-vaO">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="128"/>
@@ -1128,6 +1150,7 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="discoverRegisteredSegmentedControl" destination="T80-LS-hV3" id="qmX-pd-BVn"/>
                         <outlet property="tableView" destination="k0i-jF-q1u" id="Peb-dw-x74"/>
                     </connections>
                 </viewController>
@@ -1525,7 +1548,7 @@
     </scenes>
     <inferredMetricsTieBreakers>
         <segue reference="iPf-X4-auV"/>
-        <segue reference="tAG-hY-s6j"/>
+        <segue reference="EZ4-Jx-OHr"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="LoginScreen" width="1944.5" height="2916.5"/>

--- a/Suko/Base.lproj/Main.storyboard
+++ b/Suko/Base.lproj/Main.storyboard
@@ -1064,7 +1064,7 @@
                                     </constraints>
                                 </view>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SUKEventTableViewCell" rowHeight="128" id="ijO-jL-1gA" customClass="SUKEventTableViewCell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SUKBrowseEventTableViewCell" rowHeight="128" id="ijO-jL-1gA" customClass="SUKBrowseEventTableViewCell">
                                         <rect key="frame" x="0.0" y="99.5" width="414" height="128"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ijO-jL-1gA" id="7YT-ny-vaO">
@@ -1152,6 +1152,7 @@
                     <connections>
                         <outlet property="discoverRegisteredSegmentedControl" destination="T80-LS-hV3" id="qmX-pd-BVn"/>
                         <outlet property="tableView" destination="k0i-jF-q1u" id="Peb-dw-x74"/>
+                        <segue destination="561-x0-24T" kind="show" identifier="BrowseEventToNotCurrentUserProfileSegue" id="DYo-a4-zd2"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="MkY-1D-dQ2" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -1483,6 +1484,7 @@
                         <outlet property="profileImageView" destination="YYc-p2-EMY" id="Ksy-9R-dBp"/>
                         <outlet property="registerButton" destination="0TZ-Zo-6mI" id="Ilc-6W-idO"/>
                         <outlet property="usernameLabel" destination="ngn-le-IGH" id="t5g-eD-LC0"/>
+                        <segue destination="561-x0-24T" kind="show" identifier="EventDetailsToNotCurrentUserProfileSegue" id="rpV-XQ-NWa"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dsK-AD-rKp" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -1547,8 +1549,9 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="iPf-X4-auV"/>
-        <segue reference="EZ4-Jx-OHr"/>
+        <segue reference="rpV-XQ-NWa"/>
+        <segue reference="wz9-h9-cFl"/>
+        <segue reference="tAG-hY-s6j"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="LoginScreen" width="1944.5" height="2916.5"/>

--- a/Suko/Base.lproj/Main.storyboard
+++ b/Suko/Base.lproj/Main.storyboard
@@ -1567,7 +1567,7 @@
     </scenes>
     <inferredMetricsTieBreakers>
         <segue reference="DYo-a4-zd2"/>
-        <segue reference="wz9-h9-cFl"/>
+        <segue reference="iPf-X4-auV"/>
         <segue reference="4vs-CO-2P5"/>
     </inferredMetricsTieBreakers>
     <resources>

--- a/Suko/Base.lproj/Main.storyboard
+++ b/Suko/Base.lproj/Main.storyboard
@@ -1131,6 +1131,10 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" id="M0l-T9-9PQ">
+                                <rect key="frame" x="0.0" y="426" width="414" height="44"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            </activityIndicatorView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="kRc-2x-ysI"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -1151,6 +1155,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="discoverRegisteredSegmentedControl" destination="T80-LS-hV3" id="qmX-pd-BVn"/>
+                        <outlet property="spinner" destination="M0l-T9-9PQ" id="zqY-73-Bu3"/>
                         <outlet property="tableView" destination="k0i-jF-q1u" id="Peb-dw-x74"/>
                         <segue destination="561-x0-24T" kind="show" identifier="BrowseEventToNotCurrentUserProfileSegue" id="DYo-a4-zd2"/>
                     </connections>
@@ -1465,6 +1470,10 @@
                                     </constraints>
                                 </view>
                             </tableView>
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="qSu-q4-779">
+                                <rect key="frame" x="197" y="438" width="20" height="20"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            </activityIndicatorView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="3Iw-Yh-6iN"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -1483,6 +1492,7 @@
                         <outlet property="eventNameLabel" destination="SAG-ES-okg" id="tFv-G4-eK9"/>
                         <outlet property="profileImageView" destination="YYc-p2-EMY" id="Ksy-9R-dBp"/>
                         <outlet property="registerButton" destination="0TZ-Zo-6mI" id="Ilc-6W-idO"/>
+                        <outlet property="spinner" destination="qSu-q4-779" id="4Hv-W6-xf4"/>
                         <outlet property="usernameLabel" destination="ngn-le-IGH" id="t5g-eD-LC0"/>
                         <segue destination="561-x0-24T" kind="show" identifier="EventDetailsToNotCurrentUserProfileSegue" id="rpV-XQ-NWa"/>
                     </connections>
@@ -1549,7 +1559,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="DYo-a4-zd2"/>
+        <segue reference="rpV-XQ-NWa"/>
         <segue reference="wz9-h9-cFl"/>
         <segue reference="EZ4-Jx-OHr"/>
     </inferredMetricsTieBreakers>

--- a/Suko/Base.lproj/Main.storyboard
+++ b/Suko/Base.lproj/Main.storyboard
@@ -430,8 +430,8 @@
                         <outlet property="searchBar" destination="d03-rZ-Tgk" id="Dhd-UU-09r"/>
                         <outlet property="spinner" destination="Y0o-p9-vyC" id="iTX-bk-Ms5"/>
                         <outlet property="tableView" destination="IqB-dM-fLm" id="aOy-Kr-bFz"/>
-                        <segue destination="OiV-xg-5bj" kind="show" identifier="HomeToListSegue" id="4vs-CO-2P5"/>
-                        <segue destination="7E0-o4-0mw" kind="show" identifier="CollectionToDetailsSegue" id="wz9-h9-cFl"/>
+                        <segue destination="OiV-xg-5bj" kind="show" identifier="HomeToAnimeListSegue" id="4vs-CO-2P5"/>
+                        <segue destination="7E0-o4-0mw" kind="show" identifier="HomeCollectionCellToDetailsSegue" id="wz9-h9-cFl"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -1561,7 +1561,7 @@
     <inferredMetricsTieBreakers>
         <segue reference="rpV-XQ-NWa"/>
         <segue reference="wz9-h9-cFl"/>
-        <segue reference="EZ4-Jx-OHr"/>
+        <segue reference="4vs-CO-2P5"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="LoginScreen" width="1944.5" height="2916.5"/>

--- a/Suko/Base.lproj/Main.storyboard
+++ b/Suko/Base.lproj/Main.storyboard
@@ -1567,7 +1567,7 @@
     </scenes>
     <inferredMetricsTieBreakers>
         <segue reference="DYo-a4-zd2"/>
-        <segue reference="iPf-X4-auV"/>
+        <segue reference="wz9-h9-cFl"/>
         <segue reference="4vs-CO-2P5"/>
     </inferredMetricsTieBreakers>
     <resources>

--- a/Suko/Base.lproj/Main.storyboard
+++ b/Suko/Base.lproj/Main.storyboard
@@ -1551,7 +1551,7 @@
     <inferredMetricsTieBreakers>
         <segue reference="rpV-XQ-NWa"/>
         <segue reference="wz9-h9-cFl"/>
-        <segue reference="4vs-CO-2P5"/>
+        <segue reference="tAG-hY-s6j"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="LoginScreen" width="1944.5" height="2916.5"/>

--- a/Suko/Cells/SUKAnimeListTableViewCell.m
+++ b/Suko/Cells/SUKAnimeListTableViewCell.m
@@ -11,15 +11,11 @@
 
 - (void)awakeFromNib {
     [super awakeFromNib];
-    
-    // Remove the gray highlight after you select a cell
     self.selectionStyle = UITableViewCellSelectionStyleNone;
 }
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {
     [super setSelected:selected animated:animated];
-
-    // Configure the view for the selected state
 }
 
 @end

--- a/Suko/Cells/SUKBrowseEventTableViewCell.h
+++ b/Suko/Cells/SUKBrowseEventTableViewCell.h
@@ -11,6 +11,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@protocol SUKBrowseEventTableViewCellDelegate;
+
 @interface SUKBrowseEventTableViewCell : UITableViewCell
 
 @property (nonatomic, strong) SUKEvent *event;
@@ -18,6 +20,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) IBOutlet UILabel *usernameLabel;
 @property (weak, nonatomic) IBOutlet UILabel *eventNameLabel;
 @property (weak, nonatomic) IBOutlet UILabel *dateLabel;
+
+@property (nonatomic, weak) id<SUKBrowseEventTableViewCellDelegate> delegate;
+
+@end
+
+@protocol SUKBrowseEventTableViewCellDelegate
+- (void)profileDoneLoading:(SUKBrowseEventTableViewCell *) cell;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Suko/Cells/SUKBrowseEventTableViewCell.h
+++ b/Suko/Cells/SUKBrowseEventTableViewCell.h
@@ -1,5 +1,5 @@
 //
-//  SUKEventTableViewCell.h
+//  SUKBrowseEventTableViewCell.h
 //  Suko
 //
 //  Created by Alice Zhang on 7/19/22.
@@ -11,14 +11,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SUKEventTableViewCell : UITableViewCell
+@interface SUKBrowseEventTableViewCell : UITableViewCell
 
 @property (nonatomic, strong) SUKEvent *event;
+@property (nonatomic, strong) PFUser *poster;
 @property (weak, nonatomic) IBOutlet PFImageView *profileImageView;
 @property (weak, nonatomic) IBOutlet UILabel *usernameLabel;
 @property (weak, nonatomic) IBOutlet UILabel *eventNameLabel;
 @property (weak, nonatomic) IBOutlet UILabel *dateLabel;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Suko/Cells/SUKBrowseEventTableViewCell.h
+++ b/Suko/Cells/SUKBrowseEventTableViewCell.h
@@ -11,8 +11,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol SUKBrowseEventTableViewCellDelegate;
-
 @interface SUKBrowseEventTableViewCell : UITableViewCell
 
 @property (nonatomic, strong) SUKEvent *event;
@@ -20,13 +18,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) IBOutlet UILabel *usernameLabel;
 @property (weak, nonatomic) IBOutlet UILabel *eventNameLabel;
 @property (weak, nonatomic) IBOutlet UILabel *dateLabel;
-
-@property (nonatomic, weak) id<SUKBrowseEventTableViewCellDelegate> delegate;
-
-@end
-
-@protocol SUKBrowseEventTableViewCellDelegate
-- (void)profileDoneLoading:(SUKBrowseEventTableViewCell *) cell;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Suko/Cells/SUKBrowseEventTableViewCell.h
+++ b/Suko/Cells/SUKBrowseEventTableViewCell.h
@@ -14,7 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SUKBrowseEventTableViewCell : UITableViewCell
 
 @property (nonatomic, strong) SUKEvent *event;
-@property (nonatomic, strong) PFUser *poster;
 @property (weak, nonatomic) IBOutlet PFImageView *profileImageView;
 @property (weak, nonatomic) IBOutlet UILabel *usernameLabel;
 @property (weak, nonatomic) IBOutlet UILabel *eventNameLabel;

--- a/Suko/Cells/SUKBrowseEventTableViewCell.m
+++ b/Suko/Cells/SUKBrowseEventTableViewCell.m
@@ -19,7 +19,7 @@
     [super setSelected:selected animated:animated];
 }
 
-- (void) setEvent:(SUKEvent*) event {
+- (void)setEvent:(SUKEvent*) event {
     _event = event;
     
     self.eventNameLabel.text = event.name;
@@ -30,17 +30,21 @@
                             stringByAppendingString:@" - "]
                            stringByAppendingString:[formatter stringFromDate:event.endTime]];
     
+    __weak __typeof(self) weakSelf = self;
     [event.postedBy fetchInBackgroundWithBlock:^(PFObject * _Nullable object, NSError * _Nullable error) {
+        __strong __typeof(self) strongSelf = weakSelf;
         if(object != nil) {
             PFUser *eventPoster = (PFUser *) object;
-            self.usernameLabel.text = eventPoster.username;
-            self.profileImageView.file = eventPoster[@"profile_image"];
-            [self.profileImageView loadInBackground];
-            self.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.height /2;
-            self.profileImageView.layer.masksToBounds = YES;
-            self.profileImageView.layer.borderWidth = 0;
+            strongSelf.usernameLabel.text = eventPoster.username;
+            strongSelf.profileImageView.file = eventPoster[@"profile_image"];
+            [strongSelf.profileImageView loadInBackground];
+            strongSelf.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.height /2;
+            strongSelf.profileImageView.layer.masksToBounds = YES;
+            strongSelf.profileImageView.layer.borderWidth = 0;
             
-            [self.delegate profileDoneLoading:self];
+            [strongSelf.delegate profileDoneLoading:self];
+        } else {
+            NSLog(@"%@", error.localizedDescription);
         }
     }];
 }

--- a/Suko/Cells/SUKBrowseEventTableViewCell.m
+++ b/Suko/Cells/SUKBrowseEventTableViewCell.m
@@ -23,30 +23,18 @@
     _event = event;
     
     self.eventNameLabel.text = event.name;
+    self.usernameLabel.text = event.postedBy.username;
+    self.profileImageView.file = event.postedBy[@"profile_image"];
+    [self.profileImageView loadInBackground];
+    self.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.height /2;
+    self.profileImageView.layer.masksToBounds = YES;
+    self.profileImageView.layer.borderWidth = 0;
     
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     formatter.dateFormat = @"MM/dd/yyyy h:mm a";
     self.dateLabel.text = [[[formatter stringFromDate:event.startTime]
                             stringByAppendingString:@" - "]
                            stringByAppendingString:[formatter stringFromDate:event.endTime]];
-    
-    __weak __typeof(self) weakSelf = self;
-    [event.postedBy fetchInBackgroundWithBlock:^(PFObject * _Nullable object, NSError * _Nullable error) {
-        __strong __typeof(self) strongSelf = weakSelf;
-        if(object != nil) {
-            PFUser *eventPoster = (PFUser *) object;
-            strongSelf.usernameLabel.text = eventPoster.username;
-            strongSelf.profileImageView.file = eventPoster[@"profile_image"];
-            [strongSelf.profileImageView loadInBackground];
-            strongSelf.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.height /2;
-            strongSelf.profileImageView.layer.masksToBounds = YES;
-            strongSelf.profileImageView.layer.borderWidth = 0;
-            
-            [strongSelf.delegate profileDoneLoading:self];
-        } else {
-            NSLog(@"%@", error.localizedDescription);
-        }
-    }];
 }
 
 @end

--- a/Suko/Cells/SUKBrowseEventTableViewCell.m
+++ b/Suko/Cells/SUKBrowseEventTableViewCell.m
@@ -39,6 +39,8 @@
             self.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.height /2;
             self.profileImageView.layer.masksToBounds = YES;
             self.profileImageView.layer.borderWidth = 0;
+            
+            [self.delegate profileDoneLoading:self];
         }
     }];
 }

--- a/Suko/Cells/SUKBrowseEventTableViewCell.m
+++ b/Suko/Cells/SUKBrowseEventTableViewCell.m
@@ -19,7 +19,7 @@
     [super setSelected:selected animated:animated];
 }
 
-- (void)setEvent:(SUKEvent*) event {
+- (void)setEvent:(SUKEvent *)event {
     _event = event;
     
     self.eventNameLabel.text = event.name;

--- a/Suko/Cells/SUKBrowseEventTableViewCell.m
+++ b/Suko/Cells/SUKBrowseEventTableViewCell.m
@@ -30,7 +30,7 @@
     self.profileImageView.layer.masksToBounds = YES;
     self.profileImageView.layer.borderWidth = 0;
     
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    NSDateFormatter *formatter = [NSDateFormatter new];
     formatter.dateFormat = @"MM/dd/yyyy h:mm a";
     self.dateLabel.text = [[[formatter stringFromDate:event.startTime]
                             stringByAppendingString:@" - "]

--- a/Suko/Cells/SUKBrowseEventTableViewCell.m
+++ b/Suko/Cells/SUKBrowseEventTableViewCell.m
@@ -1,14 +1,14 @@
 //
-//  SUKEventTableViewCell.m
+//  SUKBrowseEventTableViewCell.m
 //  Suko
 //
 //  Created by Alice Zhang on 7/19/22.
 //
 
-#import "SUKEventTableViewCell.h"
+#import "SUKBrowseEventTableViewCell.h"
 #import <Parse/Parse.h>
 
-@implementation SUKEventTableViewCell
+@implementation SUKBrowseEventTableViewCell
 
 - (void)awakeFromNib {
     [super awakeFromNib];
@@ -30,15 +30,17 @@
                             stringByAppendingString:@" - "]
                            stringByAppendingString:[formatter stringFromDate:event.endTime]];
     
-    PFUser *eventPoster = event.postedBy;
-    [eventPoster fetchIfNeeded];
-    self.usernameLabel.text = eventPoster.username;
-    
-    self.profileImageView.file = eventPoster[@"profile_image"];
-    [self.profileImageView loadInBackground];
-    self.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.height /2;
-    self.profileImageView.layer.masksToBounds = YES;
-    self.profileImageView.layer.borderWidth = 0;
+    [event.postedBy fetchInBackgroundWithBlock:^(PFObject * _Nullable object, NSError * _Nullable error) {
+        if(object != nil) {
+            PFUser *eventPoster = (PFUser *) object;
+            self.usernameLabel.text = eventPoster.username;
+            self.profileImageView.file = eventPoster[@"profile_image"];
+            [self.profileImageView loadInBackground];
+            self.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.height /2;
+            self.profileImageView.layer.masksToBounds = YES;
+            self.profileImageView.layer.borderWidth = 0;
+        }
+    }];
 }
 
 @end

--- a/Suko/Cells/SUKEventTableViewCell.h
+++ b/Suko/Cells/SUKEventTableViewCell.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SUKEventTableViewCell : UITableViewCell
 
 @property (nonatomic, strong) SUKEvent *event;
-@property (weak, nonatomic) IBOutlet PFImageView *userProfileImage;
+@property (weak, nonatomic) IBOutlet PFImageView *profileImageView;
 @property (weak, nonatomic) IBOutlet UILabel *usernameLabel;
 @property (weak, nonatomic) IBOutlet UILabel *eventNameLabel;
 @property (weak, nonatomic) IBOutlet UILabel *dateLabel;

--- a/Suko/Cells/SUKEventTableViewCell.m
+++ b/Suko/Cells/SUKEventTableViewCell.m
@@ -34,11 +34,11 @@
     [eventPoster fetchIfNeeded];
     self.usernameLabel.text = eventPoster.username;
     
-    self.userProfileImage.file = eventPoster[@"profile_image"];
-    [self.userProfileImage loadInBackground];
-    self.userProfileImage.layer.cornerRadius = self.userProfileImage.frame.size.height /2;
-    self.userProfileImage.layer.masksToBounds = YES;
-    self.userProfileImage.layer.borderWidth = 0;
+    self.profileImageView.file = eventPoster[@"profile_image"];
+    [self.profileImageView loadInBackground];
+    self.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.height /2;
+    self.profileImageView.layer.masksToBounds = YES;
+    self.profileImageView.layer.borderWidth = 0;
 }
 
 @end

--- a/Suko/Cells/SUKHomeTableViewCell.h
+++ b/Suko/Cells/SUKHomeTableViewCell.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** The label that says "see all" */
 @property (weak, nonatomic) IBOutlet UILabel *seeAllLabel;
 /** The anime being displayed in this cell's collection view */
-@property (nonatomic, strong) NSArray<SUKAnime*> *arrOfAnime;
+@property (nonatomic, strong) NSArray<SUKAnime *> *arrOfAnime;
 /** This cell's  SUKHomeTableViewCellDelegate delegate */
 @property (nonatomic, weak) id<SUKHomeTableViewCellDelegate> delegate;
 
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
  * A delegate to handle segue from SUKHomeTableViewCell to some other view controller (ex. SUKAnimeListViewController)
  */
 @protocol SUKHomeTableViewCellDelegate
-- (void)segueSUKHomeTableViewCell:(SUKHomeTableViewCell *) cell;
+- (void)segueSUKHomeTableViewCell:(SUKHomeTableViewCell *)cell;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Suko/Cells/SUKHomeTableViewCell.m
+++ b/Suko/Cells/SUKHomeTableViewCell.m
@@ -16,9 +16,8 @@
 - (void)awakeFromNib {
     [super awakeFromNib];
     
-    self.selectionStyle = UITableViewCellSelectionStyleNone; // Remove the gray highlight after you select a cell
+    self.selectionStyle = UITableViewCellSelectionStyleNone;
     
-    // Add tap gesture recognizer to the see all label so that when a user taps, the app segue
     UITapGestureRecognizer *seeAllTapGestureRecognizer = [[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(didTapSeeAll:)];
     [self.seeAllLabel addGestureRecognizer:seeAllTapGestureRecognizer];
     [self.seeAllLabel setUserInteractionEnabled:YES];

--- a/Suko/Cells/SUKHomeTableViewCell.m
+++ b/Suko/Cells/SUKHomeTableViewCell.m
@@ -23,11 +23,11 @@
     [self.seeAllLabel setUserInteractionEnabled:YES];
 }
 
-- (void) didTapSeeAll:(UITapGestureRecognizer *)sender{
+- (void)didTapSeeAll:(UITapGestureRecognizer *)sender {
     [self.delegate segueSUKHomeTableViewCell:self];
 }
 
-- (void)setCollectionViewDataSourceDelegate:(id<UICollectionViewDataSource, UICollectionViewDelegate>)dataSourceDelegate indexPath:(NSIndexPath *)indexPath{
+- (void)setCollectionViewDataSourceDelegate:(id<UICollectionViewDataSource, UICollectionViewDelegate>)dataSourceDelegate indexPath:(NSIndexPath *)indexPath {
     self.collectionView.dataSource = dataSourceDelegate;
     self.collectionView.delegate = dataSourceDelegate;
     self.collectionView.indexPath = indexPath;

--- a/Suko/Cells/SUKLibraryTableViewCell.m
+++ b/Suko/Cells/SUKLibraryTableViewCell.m
@@ -11,15 +11,11 @@
 
 - (void)awakeFromNib {
     [super awakeFromNib];
-    
-    // Remove the gray highlight after you select a cell
     self.selectionStyle = UITableViewCellSelectionStyleNone;
 }
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {
     [super setSelected:selected animated:animated];
-
-    // Configure the view for the selected state
 }
 
 @end

--- a/Suko/Model/SUKAnime.h
+++ b/Suko/Model/SUKAnime.h
@@ -20,13 +20,13 @@ NS_ASSUME_NONNULL_BEGIN
 /** The anime synopsis */
 @property (nonatomic) NSString *synopsis;
 /** The genres this anime fit into */
-@property (nonatomic) NSArray *genres;
+@property (nonatomic) NSArray<NSDictionary*> *genres;
 /** Episode count */
 @property (nonatomic) int episodes;
 /** Airing status ("Finished Airing," "Currently Airing," "Not yet aired")*/
 @property (nonatomic) NSString *status;
 
-+ (NSMutableArray *)animesWithArrayOfDictionaries:(NSArray *)dictionaries;
++ (NSMutableArray<SUKAnime*> *)animesWithArrayOfDictionaries:(NSArray<NSDictionary*> *)dictionaries;
 + (SUKAnime *)animeWithDictionary:(NSDictionary *)dictionary;
 
 @end

--- a/Suko/Model/SUKAnime.h
+++ b/Suko/Model/SUKAnime.h
@@ -20,13 +20,13 @@ NS_ASSUME_NONNULL_BEGIN
 /** The anime synopsis */
 @property (nonatomic) NSString *synopsis;
 /** The genres this anime fit into */
-@property (nonatomic) NSArray<NSDictionary*> *genres;
+@property (nonatomic) NSArray<NSDictionary *> *genres;
 /** Episode count */
 @property (nonatomic) int numEpisodes;
 /** Airing status ("Finished Airing," "Currently Airing," "Not yet aired")*/
 @property (nonatomic) NSString *status;
 
-+ (NSMutableArray<SUKAnime*> *)animesWithArrayOfDictionaries:(NSArray<NSDictionary*> *)dictionaries;
++ (NSMutableArray<SUKAnime *> *)animesWithArrayOfDictionaries:(NSArray<NSDictionary *> *)dictionaries;
 + (SUKAnime *)animeWithDictionary:(NSDictionary *)dictionary;
 
 @end

--- a/Suko/Model/SUKAnime.h
+++ b/Suko/Model/SUKAnime.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** The genres this anime fit into */
 @property (nonatomic) NSArray<NSDictionary*> *genres;
 /** Episode count */
-@property (nonatomic) int episodes;
+@property (nonatomic) int numEpisodes;
 /** Airing status ("Finished Airing," "Currently Airing," "Not yet aired")*/
 @property (nonatomic) NSString *status;
 

--- a/Suko/Model/SUKAnime.h
+++ b/Suko/Model/SUKAnime.h
@@ -11,14 +11,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SUKAnime : NSObject
 
-@property (nonatomic) int malID; // MyAnimeList ID
-@property (nonatomic) NSString *title; // The title of the anime (ex. "One Piece")
-@property (nonatomic) NSString *posterURL; // The URL for the poster of the anime
-@property (nonatomic) NSString *synopsis; // The anime synopsis
-@property (nonatomic) NSArray *genres; // The genres this anime fit into
-
-@property (nonatomic) int episodes; // Episode count
-@property (nonatomic) NSString *status; // Airing status ("Finished Airing," "Currently Airing," "Not yet aired")
+/** Corresponding MyAnimeList ID */
+@property (nonatomic) int malID;
+/** The title of the anime (ex. "One Piece") */
+@property (nonatomic) NSString *title;
+/** The URL for the poster of the anime */
+@property (nonatomic) NSString *posterURL;
+/** The anime synopsis */
+@property (nonatomic) NSString *synopsis;
+/** The genres this anime fit into */
+@property (nonatomic) NSArray *genres;
+/** Episode count */
+@property (nonatomic) int episodes;
+/** Airing status ("Finished Airing," "Currently Airing," "Not yet aired")*/
+@property (nonatomic) NSString *status;
 
 + (NSMutableArray *)animesWithArrayOfDictionaries:(NSArray *)dictionaries;
 + (SUKAnime *)animeWithDictionary:(NSDictionary *)dictionary;

--- a/Suko/Model/SUKAnime.m
+++ b/Suko/Model/SUKAnime.m
@@ -26,7 +26,7 @@
         self.status = dictionary[@"status"];
 
         NSNumber *episodesNSNumber = dictionary[@"episodes"];
-        self.episodes = [episodesNSNumber intValue];
+        self.numEpisodes = [episodesNSNumber intValue];
     }
     
     return self;

--- a/Suko/Model/SUKAnime.m
+++ b/Suko/Model/SUKAnime.m
@@ -32,8 +32,8 @@
     return self;
 }
 
-+ (NSMutableArray<SUKAnime*> *)animesWithArrayOfDictionaries:(NSArray<NSDictionary*> *)dictionaries {
-    NSMutableArray<SUKAnime*> *animes = [NSMutableArray array];
++ (NSMutableArray<SUKAnime *> *)animesWithArrayOfDictionaries:(NSArray<NSDictionary *> *)dictionaries {
+    NSMutableArray<SUKAnime *> *animes = [NSMutableArray array];
     for (NSDictionary *dictionary in dictionaries) {
         SUKAnime *anime = [[SUKAnime alloc] initWithDictionary:dictionary];
         [animes addObject:anime];

--- a/Suko/Model/SUKAnime.m
+++ b/Suko/Model/SUKAnime.m
@@ -16,7 +16,7 @@
         NSNumber *malIDNSNumber = dictionary[@"mal_id"];
         self.malID = [malIDNSNumber intValue];
         
-        // MyAnimeList formats titles weirdly occasionally with "\" at the end, so we need to remove the formatting
+        // MyAnimeList formats titles occasionally with "\" at the end, so need to remove the formatting
         NSString *titleWithMALFormatting = dictionary[@"title"];
         self.title = [[titleWithMALFormatting componentsSeparatedByString:@"\\"] objectAtIndex:0];
         

--- a/Suko/Model/SUKAnime.m
+++ b/Suko/Model/SUKAnime.m
@@ -21,21 +21,19 @@
         self.title = [[titleWithMALFormatting componentsSeparatedByString:@"\\"] objectAtIndex:0];
         
         self.posterURL = dictionary[@"images"][@"jpg"][@"large_image_url"];
-        
         self.synopsis = dictionary[@"synopsis"];
         self.genres = dictionary[@"genres"];
-        
+        self.status = dictionary[@"status"];
+
         NSNumber *episodesNSNumber = dictionary[@"episodes"];
         self.episodes = [episodesNSNumber intValue];
-        
-        self.status = dictionary[@"status"];
     }
     
     return self;
 }
 
-+ (NSMutableArray *)animesWithArrayOfDictionaries:(NSArray *)dictionaries {
-    NSMutableArray *animes = [NSMutableArray array];
++ (NSMutableArray<SUKAnime*> *)animesWithArrayOfDictionaries:(NSArray<NSDictionary*> *)dictionaries {
+    NSMutableArray<SUKAnime*> *animes = [NSMutableArray array];
     for (NSDictionary *dictionary in dictionaries) {
         SUKAnime *anime = [[SUKAnime alloc] initWithDictionary:dictionary];
         [animes addObject:anime];

--- a/Suko/Model/SUKAnime.m
+++ b/Suko/Model/SUKAnime.m
@@ -33,7 +33,7 @@
 }
 
 + (NSMutableArray<SUKAnime *> *)animesWithArrayOfDictionaries:(NSArray<NSDictionary *> *)dictionaries {
-    NSMutableArray<SUKAnime *> *animes = [NSMutableArray array];
+    NSMutableArray<SUKAnime *> *animes = [NSMutableArray new];
     for (NSDictionary *dictionary in dictionaries) {
         SUKAnime *anime = [[SUKAnime alloc] initWithDictionary:dictionary];
         [animes addObject:anime];

--- a/Suko/Model/SUKEvent.h
+++ b/Suko/Model/SUKEvent.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSDate *endTime;
 /** The user posting the event */
 @property (nonatomic, strong) PFUser *postedBy;
+@property (nonatomic, strong) NSString *organizerID;
 /** The attendees of the event as represented by an array containing their user object IDs */
 @property (nonatomic, strong) NSArray<NSString*> *attendees;
 

--- a/Suko/Model/SUKEvent.h
+++ b/Suko/Model/SUKEvent.h
@@ -23,9 +23,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** The user posting the event */
 @property (nonatomic, strong) PFUser *postedBy;
 /** The attendees of the event as represented by an array containing their user object IDs */
-@property (nonatomic, strong) NSArray<NSString*> *attendees;
+@property (nonatomic, strong) NSArray<NSString *> *attendees;
 
-+ (void) postEventWithName:(NSString *) eventName eventDescription:(NSString *) eventDescription eventLocation:(CLLocation *) eventLocation startTime:(NSDate *) startTime endTime:(NSDate *) endTime postedBy:(PFUser *) user withCompletion: (PFBooleanResultBlock  _Nullable)completion;
++ (void)postEventWithName:(NSString *)eventName eventDescription:(NSString *)eventDescription eventLocation:(CLLocation *)eventLocation startTime:(NSDate *)startTime endTime:(NSDate *)endTime postedBy:(PFUser *)user withCompletion:(PFBooleanResultBlock  _Nullable)completion;
 
 @end
 

--- a/Suko/Model/SUKEvent.h
+++ b/Suko/Model/SUKEvent.h
@@ -10,12 +10,19 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SUKEvent : PFObject<PFSubclassing>
+/** The name of the event as submitted by the user posting the event */
 @property (nonatomic, strong) NSString *name;
+/** The description of the event as submitted by the user posting the event */
 @property (nonatomic, strong) NSString *eventDescription;
+/** The coordinates of the event as chosen by the user posting the event */
 @property (nonatomic, strong) PFGeoPoint *location;
+/** The start time of the event as submitted by the user posting the event */
 @property (nonatomic, strong) NSDate *startTime;
+/** The end time of the event as submitted by the user posting the event */
 @property (nonatomic, strong) NSDate *endTime;
+/** The user posting the event */
 @property (nonatomic, strong) PFUser *postedBy;
+/** The attendees of the event as represented by an array containing their user object IDs */
 @property (nonatomic, strong) NSArray<NSString*> *attendees;
 
 + (void) postEventWithName:(NSString *) eventName eventDescription:(NSString *) eventDescription eventLocation:(CLLocation *) eventLocation startTime:(NSDate *) startTime endTime:(NSDate *) endTime postedBy:(PFUser *) user withCompletion: (PFBooleanResultBlock  _Nullable)completion;

--- a/Suko/Model/SUKEvent.h
+++ b/Suko/Model/SUKEvent.h
@@ -22,7 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSDate *endTime;
 /** The user posting the event */
 @property (nonatomic, strong) PFUser *postedBy;
-@property (nonatomic, strong) NSString *organizerID;
 /** The attendees of the event as represented by an array containing their user object IDs */
 @property (nonatomic, strong) NSArray<NSString*> *attendees;
 

--- a/Suko/Model/SUKEvent.m
+++ b/Suko/Model/SUKEvent.m
@@ -17,6 +17,7 @@
 @dynamic endTime;
 @dynamic postedBy;
 @dynamic attendees;
+@dynamic organizerID;
 
 + (nonnull NSString *)parseClassName {
     return @"SUKEvent";
@@ -31,6 +32,7 @@
     newEvent.startTime = startTime;
     newEvent.endTime = endTime;
     newEvent.postedBy = user;
+    newEvent.organizerID = user.objectId;
     newEvent.attendees = [[NSArray alloc] init];
     
     [newEvent saveInBackgroundWithBlock: completion];

--- a/Suko/Model/SUKEvent.m
+++ b/Suko/Model/SUKEvent.m
@@ -17,7 +17,6 @@
 @dynamic endTime;
 @dynamic postedBy;
 @dynamic attendees;
-@dynamic organizerID;
 
 + (nonnull NSString *)parseClassName {
     return @"SUKEvent";
@@ -32,8 +31,7 @@
     newEvent.startTime = startTime;
     newEvent.endTime = endTime;
     newEvent.postedBy = user;
-    newEvent.organizerID = user.objectId;
-    newEvent.attendees = [[NSArray alloc] init];
+    newEvent.attendees = [NSArray new];
     
     [newEvent saveInBackgroundWithBlock: completion];
 }

--- a/Suko/Model/SUKEvent.m
+++ b/Suko/Model/SUKEvent.m
@@ -22,7 +22,7 @@
     return @"SUKEvent";
 }
 
-+ (void) postEventWithName:(NSString *) eventName eventDescription:(NSString *) eventDescription eventLocation:(CLLocation *) eventLocation startTime:(NSDate *) startTime endTime:(NSDate *) endTime postedBy:(PFUser *) user withCompletion: (PFBooleanResultBlock  _Nullable)completion {
++ (void)postEventWithName:(NSString *)eventName eventDescription:(NSString *)eventDescription eventLocation:(CLLocation *)eventLocation startTime:(NSDate *)startTime endTime:(NSDate *)endTime postedBy:(PFUser *)user withCompletion:(PFBooleanResultBlock  _Nullable)completion {
     SUKEvent *newEvent = [SUKEvent new];
     
     newEvent.name = eventName;

--- a/Suko/Model/SUKFollow.h
+++ b/Suko/Model/SUKFollow.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) PFUser *follower;
 @property (nonatomic, strong) PFUser *userBeingFollowed;
 
-+ (void) postFollow:(PFUser*) follower userBeingFollowed:(PFUser*) followed withCompletion: (PFBooleanResultBlock  _Nullable)completion;
++ (void) postFollowWithFollower:(PFUser*) follower userBeingFollowed:(PFUser*) followed withCompletion: (PFBooleanResultBlock  _Nullable)completion;
 + (void) deleteFollow: (SUKFollow * _Nullable) follow;
 
 @end

--- a/Suko/Model/SUKFollow.h
+++ b/Suko/Model/SUKFollow.h
@@ -10,7 +10,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SUKFollow : PFObject<PFSubclassing>
+/** The user who is doing the following */
 @property (nonatomic, strong) PFUser *follower;
+/** The user who is being followed */
 @property (nonatomic, strong) PFUser *userBeingFollowed;
 
 + (void) postFollowWithFollower:(PFUser*) follower userBeingFollowed:(PFUser*) followed withCompletion: (PFBooleanResultBlock  _Nullable)completion;

--- a/Suko/Model/SUKFollow.h
+++ b/Suko/Model/SUKFollow.h
@@ -15,8 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 /** The user who is being followed */
 @property (nonatomic, strong) PFUser *userBeingFollowed;
 
-+ (void) postFollowWithFollower:(PFUser*) follower userBeingFollowed:(PFUser*) followed withCompletion: (PFBooleanResultBlock  _Nullable)completion;
-+ (void) deleteFollow: (SUKFollow * _Nullable) follow;
++ (void)postFollowWithFollower:(PFUser *)follower userBeingFollowed:(PFUser *)followed withCompletion:(PFBooleanResultBlock  _Nullable)completion;
++ (void)deleteFollow:(SUKFollow * _Nullable)follow;
 
 @end
 

--- a/Suko/Model/SUKFollow.m
+++ b/Suko/Model/SUKFollow.m
@@ -19,7 +19,6 @@
 + (void) postFollowWithFollower:(PFUser*) follower userBeingFollowed:(PFUser*) followed withCompletion: (PFBooleanResultBlock  _Nullable)completion {
     SUKFollow *newFollow = [SUKFollow new];
     
-    // Set up the columns
     newFollow.follower = follower;
     newFollow.userBeingFollowed = followed;
     

--- a/Suko/Model/SUKFollow.m
+++ b/Suko/Model/SUKFollow.m
@@ -16,7 +16,7 @@
     return @"SUKFollow";
 }
 
-+ (void) postFollow:(PFUser*) follower userBeingFollowed:(PFUser*) followed withCompletion: (PFBooleanResultBlock  _Nullable)completion {
++ (void) postFollowWithFollower:(PFUser*) follower userBeingFollowed:(PFUser*) followed withCompletion: (PFBooleanResultBlock  _Nullable)completion {
     SUKFollow *newFollow = [SUKFollow new];
     
     // Set up the columns

--- a/Suko/Model/SUKFollow.m
+++ b/Suko/Model/SUKFollow.m
@@ -16,7 +16,7 @@
     return @"SUKFollow";
 }
 
-+ (void) postFollowWithFollower:(PFUser*) follower userBeingFollowed:(PFUser*) followed withCompletion: (PFBooleanResultBlock  _Nullable)completion {
++ (void)postFollowWithFollower:(PFUser *)follower userBeingFollowed:(PFUser *)followed withCompletion:(PFBooleanResultBlock  _Nullable)completion {
     SUKFollow *newFollow = [SUKFollow new];
     
     newFollow.follower = follower;
@@ -25,7 +25,7 @@
     [newFollow saveInBackgroundWithBlock: completion];
 }
 
-+ (void) deleteFollow: (SUKFollow * _Nullable) follow {
++ (void)deleteFollow:(SUKFollow * _Nullable)follow {
     [follow deleteInBackgroundWithBlock:^(BOOL succeeded, NSError * _Nullable error) {
         if (succeeded) {
             NSLog(@"Successfully deleted the follow");

--- a/Suko/View Controller/SUKAnimeListViewController.h
+++ b/Suko/View Controller/SUKAnimeListViewController.h
@@ -14,9 +14,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** The title of the list being displayed */
 @property (nonatomic, strong) NSString *listTitle;
 /** Array of anime in the list, with each anime stored as a SUKAnime object */
-@property (nonatomic, strong) NSArray<SUKAnime*> *arrOfAnime;
+@property (nonatomic, strong) NSArray<SUKAnime *> *arrOfAnime;
 /** Array of anime in the list, with each anime stored as its MyAnimeList ID */
-@property (nonatomic, strong) NSArray<NSNumber*> *arrOfAnimeMALID;
+@property (nonatomic, strong) NSArray<NSNumber *> *arrOfAnimeMALID;
 
 @end
 

--- a/Suko/View Controller/SUKAnimeListViewController.h
+++ b/Suko/View Controller/SUKAnimeListViewController.h
@@ -11,12 +11,12 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SUKAnimeListViewController : UIViewController <UITableViewDataSource, UITableViewDelegate>
-@property (nonatomic, strong) NSString *listTitle; // the title of the list
-@property (nonatomic, strong) NSArray<SUKAnime*> *arrOfAnime; // the animes to display
-@property (nonatomic, strong) NSArray<NSNumber*> *arrOfAnimeMALID; // the animes to display
-@property (nonatomic, strong) PFUser *userToDisplay; // which user's want to watch, watching, and watched lists to display
-
-typedef NS_ENUM(NSInteger, DefaultLibraryLists) {DefaultLibraryListsWantToWatch, DefaultLibraryListsWatching, DefaultLibraryListsWatched};
+/** The title of the list being displayed */
+@property (nonatomic, strong) NSString *listTitle;
+/** Array of anime in the list, with each anime stored as a SUKAnime object */
+@property (nonatomic, strong) NSArray<SUKAnime*> *arrOfAnime;
+/** Array of anime in the list, with each anime stored as its MyAnimeList ID */
+@property (nonatomic, strong) NSArray<NSNumber*> *arrOfAnimeMALID;
 
 @end
 

--- a/Suko/View Controller/SUKAnimeListViewController.m
+++ b/Suko/View Controller/SUKAnimeListViewController.m
@@ -38,6 +38,7 @@
             __strong __typeof(self) strongSelf = weakSelf;
             [strongSelf updateArrOfAnime];
             dispatch_sync(dispatch_get_main_queue(), ^{
+                [self.tableView reloadData];
                 [self.spinner stopAnimating];
             });
         });
@@ -57,7 +58,6 @@
                 NSMutableArray<SUKAnime *> *currentArrOfAnime = [self.arrOfAnime mutableCopy];
                 [currentArrOfAnime addObject:anime];
                 strongSelf.arrOfAnime = [currentArrOfAnime copy];
-                [strongSelf.tableView reloadData];
             } else {
                 NSLog(@"%@", error.localizedDescription);
             }

--- a/Suko/View Controller/SUKAnimeListViewController.m
+++ b/Suko/View Controller/SUKAnimeListViewController.m
@@ -81,7 +81,7 @@
     
     cell.titleLabel.text = animeToDisplay.title;
     
-    NSString *numOfEpString = [NSString stringWithFormat:@"%d", animeToDisplay.episodes];
+    NSString *numOfEpString = [NSString stringWithFormat:@"%d", animeToDisplay.numEpisodes];
     cell.numOfEpLabel.text = [numOfEpString stringByAppendingString:@" Episodes"];
     
     NSString *animePosterURLString = animeToDisplay.posterURL;

--- a/Suko/View Controller/SUKAnimeListViewController.m
+++ b/Suko/View Controller/SUKAnimeListViewController.m
@@ -46,15 +46,15 @@
     }
 }
 
--(void) updateArrOfAnime {
+- (void)updateArrOfAnime {
     for(int i = 0; i < self.arrOfAnimeMALID.count; i++) {
         NSNumber *malID = [self.arrOfAnimeMALID objectAtIndex:i];
         
         __weak __typeof(self) weakSelf = self;
-        [[SUKAPIManager shared] fetchSpecificAnimeByID:malID completion:^(SUKAnime *anime, NSError *error) {
+        [[SUKAPIManager shared] fetchAnimeWithID:malID completion:^(SUKAnime *anime, NSError *error) {
             __strong __typeof(self) strongSelf = weakSelf;
             if (anime != nil) {
-                NSMutableArray<SUKAnime*> *currentArrOfAnime = [self.arrOfAnime mutableCopy];
+                NSMutableArray<SUKAnime *> *currentArrOfAnime = [self.arrOfAnime mutableCopy];
                 [currentArrOfAnime addObject:anime];
                 strongSelf.arrOfAnime = [currentArrOfAnime copy];
                 [strongSelf.tableView reloadData];
@@ -69,11 +69,11 @@
  
 #pragma mark - TableView
 
--(NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section{
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     return self.arrOfAnime.count;
 }
 
--(UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath{
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     static NSString *cellIdentifier = @"SUKAnimeListTableViewCell";
     SUKAnimeListTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:cellIdentifier];
     
@@ -98,7 +98,7 @@
 
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
     if([segue.identifier isEqualToString: @"DetailsSegue"]) {
-        NSIndexPath *indexPath = [self.tableView indexPathForCell: (SUKAnimeListTableViewCell*) sender];
+        NSIndexPath *indexPath = [self.tableView indexPathForCell: (SUKAnimeListTableViewCell *) sender];
         SUKAnime *dataToPass = self.arrOfAnime[indexPath.row];
         SUKDetailsViewController *detailVC = [segue destinationViewController];
         detailVC.animeToDisplay = dataToPass;

--- a/Suko/View Controller/SUKAnimeListViewController.m
+++ b/Suko/View Controller/SUKAnimeListViewController.m
@@ -46,6 +46,11 @@
     }
 }
 
+- (void)viewWillDisappear:(BOOL)animated {
+    [self.spinner stopAnimating];
+    [[SUKAPIManager shared] cancelAllRequests]; // Reduce the number of requests made to external API
+}
+
 - (void)updateArrOfAnime {
     if(self.arrOfAnimeMALID.count == 0) {
         [self emptyTableView];
@@ -53,7 +58,6 @@
         
     for(int i = 0; i < self.arrOfAnimeMALID.count; i++) {
         NSNumber *malID = [self.arrOfAnimeMALID objectAtIndex:i];
-        
         __weak __typeof(self) weakSelf = self;
         [[SUKAPIManager shared] fetchAnimeWithID:malID completion:^(SUKAnime *anime, NSError *error) {
             __strong __typeof(self) strongSelf = weakSelf;

--- a/Suko/View Controller/SUKAnimeListViewController.m
+++ b/Suko/View Controller/SUKAnimeListViewController.m
@@ -22,9 +22,9 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-
+    
     self.navigationItem.title = self.listTitle;
-
+    
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     self.tableView.rowHeight = UITableViewAutomaticDimension;
@@ -38,17 +38,23 @@
             __strong __typeof(self) strongSelf = weakSelf;
             [strongSelf updateArrOfAnime];
             dispatch_sync(dispatch_get_main_queue(), ^{
+                if(self.arrOfAnime.count == 0) {
+                    [self emptyTableView];
+                }
                 [self.tableView reloadData];
                 [self.spinner stopAnimating];
             });
         });
     } else {
+        [self emptyTableView];
         [self.spinner stopAnimating];
     }
 }
 
 - (void)updateArrOfAnime {
     for(int i = 0; i < self.arrOfAnimeMALID.count; i++) {
+        [NSThread sleepForTimeInterval:1.0];
+        
         NSNumber *malID = [self.arrOfAnimeMALID objectAtIndex:i];
         
         __weak __typeof(self) weakSelf = self;
@@ -62,11 +68,9 @@
                 NSLog(@"%@", error.localizedDescription);
             }
         }];
-        
-        [NSThread sleepForTimeInterval:0.7];
     }
 }
- 
+
 #pragma mark - TableView
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
@@ -89,10 +93,21 @@
     if (url != nil) {
         [cell.posterView setImageWithURL:url];
     }
-
+    
     return cell;
 }
 
+- (void)emptyTableView {
+    UILabel *emptyListMessageLabel = [[UILabel alloc] initWithFrame:CGRectMake(40, 70, self.tableView.bounds.size.width/2, self.tableView.bounds.size.height/2)];
+    emptyListMessageLabel.backgroundColor = [UIColor clearColor];
+    emptyListMessageLabel.textAlignment = NSTextAlignmentCenter;
+    emptyListMessageLabel.textColor = [UIColor blackColor];
+    emptyListMessageLabel.numberOfLines = 0;
+    emptyListMessageLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    emptyListMessageLabel.text = @"No anime in this list yet.";
+    self.tableView.backgroundView = emptyListMessageLabel;
+    self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+}
 
 #pragma mark - Navigation
 

--- a/Suko/View Controller/SUKAnimeListViewController.m
+++ b/Suko/View Controller/SUKAnimeListViewController.m
@@ -30,6 +30,8 @@
     self.tableView.rowHeight = UITableViewAutomaticDimension;
     
     self.spinner.hidesWhenStopped = YES;
+    self.spinner.layer.cornerRadius = 10;
+    [self.spinner setCenter:CGPointMake(self.view.bounds.size.width/2.0, self.view.bounds.size.height/2.0)];
     [self.spinner startAnimating];
     
     if([self.arrOfAnime count] == 0 && self.arrOfAnimeMALID != nil && self.arrOfAnimeMALID.count > 0){
@@ -37,13 +39,6 @@
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             __strong __typeof(self) strongSelf = weakSelf;
             [strongSelf updateArrOfAnime];
-            dispatch_sync(dispatch_get_main_queue(), ^{
-                if(self.arrOfAnime.count == 0) {
-                    [self emptyTableView];
-                }
-                [self.tableView reloadData];
-                [self.spinner stopAnimating];
-            });
         });
     } else {
         [self emptyTableView];
@@ -52,22 +47,31 @@
 }
 
 - (void)updateArrOfAnime {
-    for(int i = 0; i < self.arrOfAnimeMALID.count; i++) {
-        [NSThread sleepForTimeInterval:1.0];
+    if(self.arrOfAnimeMALID.count == 0) {
+        [self emptyTableView];
+    }
         
+    for(int i = 0; i < self.arrOfAnimeMALID.count; i++) {
         NSNumber *malID = [self.arrOfAnimeMALID objectAtIndex:i];
         
         __weak __typeof(self) weakSelf = self;
         [[SUKAPIManager shared] fetchAnimeWithID:malID completion:^(SUKAnime *anime, NSError *error) {
             __strong __typeof(self) strongSelf = weakSelf;
-            if (anime != nil) {
+            if (error == nil) {
                 NSMutableArray<SUKAnime *> *currentArrOfAnime = [self.arrOfAnime mutableCopy];
                 [currentArrOfAnime addObject:anime];
                 strongSelf.arrOfAnime = [currentArrOfAnime copy];
+                [strongSelf.tableView reloadData];
             } else {
                 NSLog(@"%@", error.localizedDescription);
             }
+            
+            if(i == strongSelf.arrOfAnimeMALID.count - 1) {
+                [strongSelf.spinner stopAnimating];
+            }
         }];
+        
+        [NSThread sleepForTimeInterval:1.2];
     }
 }
 

--- a/Suko/View Controller/SUKAnimeListViewController.m
+++ b/Suko/View Controller/SUKAnimeListViewController.m
@@ -54,7 +54,7 @@
         [[SUKAPIManager shared] fetchSpecificAnimeByID:malID completion:^(SUKAnime *anime, NSError *error) {
             __strong __typeof(self) strongSelf = weakSelf;
             if (anime != nil) {
-                NSMutableArray *currentArrOfAnime = [self.arrOfAnime mutableCopy];
+                NSMutableArray<SUKAnime*> *currentArrOfAnime = [self.arrOfAnime mutableCopy];
                 [currentArrOfAnime addObject:anime];
                 strongSelf.arrOfAnime = [currentArrOfAnime copy];
                 [strongSelf.tableView reloadData];

--- a/Suko/View Controller/SUKAnimeListViewController.m
+++ b/Suko/View Controller/SUKAnimeListViewController.m
@@ -24,8 +24,7 @@
     [super viewDidLoad];
 
     self.navigationItem.title = self.listTitle;
-    
-    // Set up TableView
+
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     self.tableView.rowHeight = UITableViewAutomaticDimension;

--- a/Suko/View Controller/SUKAnimeListViewController.m
+++ b/Suko/View Controller/SUKAnimeListViewController.m
@@ -33,8 +33,10 @@
     [self.spinner startAnimating];
     
     if([self.arrOfAnime count] == 0 && self.arrOfAnimeMALID != nil && self.arrOfAnimeMALID.count > 0){
+        __weak __typeof(self) weakSelf = self;
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            [self updateArrOfAnime];
+            __strong __typeof(self) strongSelf = weakSelf;
+            [strongSelf updateArrOfAnime];
             dispatch_sync(dispatch_get_main_queue(), ^{
                 [self.spinner stopAnimating];
             });
@@ -48,12 +50,14 @@
     for(int i = 0; i < self.arrOfAnimeMALID.count; i++) {
         NSNumber *malID = [self.arrOfAnimeMALID objectAtIndex:i];
         
+        __weak __typeof(self) weakSelf = self;
         [[SUKAPIManager shared] fetchSpecificAnimeByID:malID completion:^(SUKAnime *anime, NSError *error) {
+            __strong __typeof(self) strongSelf = weakSelf;
             if (anime != nil) {
                 NSMutableArray *currentArrOfAnime = [self.arrOfAnime mutableCopy];
                 [currentArrOfAnime addObject:anime];
-                self.arrOfAnime = [currentArrOfAnime copy];
-                [self.tableView reloadData];
+                strongSelf.arrOfAnime = [currentArrOfAnime copy];
+                [strongSelf.tableView reloadData];
             } else {
                 NSLog(@"%@", error.localizedDescription);
             }

--- a/Suko/View Controller/SUKBrowseEventViewController.m
+++ b/Suko/View Controller/SUKBrowseEventViewController.m
@@ -32,13 +32,13 @@
     self.tableView.dataSource = self;
     self.tableView.rowHeight = UITableViewAutomaticDimension;
     
-    self.refreshControl = [[UIRefreshControl alloc] init];
+    self.refreshControl = [UIRefreshControl new];
     [self.refreshControl addTarget:self action:@selector(refreshData) forControlEvents:UIControlEventValueChanged];
     [self.tableView insertSubview:self.refreshControl atIndex:0];
     
-    self.arrOfEvents = [[NSArray alloc] init];
+    self.arrOfEvents = [NSArray new];
     
-    self.locationManager = [[CLLocationManager alloc] init];
+    self.locationManager = [CLLocationManager new];
     self.locationManager.delegate = self;
     self.locationManager.distanceFilter = kCLDistanceFilterNone;
     self.locationManager.desiredAccuracy = kCLLocationAccuracyBest;

--- a/Suko/View Controller/SUKBrowseEventViewController.m
+++ b/Suko/View Controller/SUKBrowseEventViewController.m
@@ -57,7 +57,7 @@
     [self.spinner startAnimating];
 }
 
-- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations {
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation*>*)locations {
     PFGeoPoint *point = [PFGeoPoint geoPointWithLocation:[locations lastObject]];
     [PFUser currentUser][@"current_coordinates"] = point;
     [[PFUser currentUser] saveInBackground];
@@ -86,7 +86,7 @@
 }
 
 - (void)browseEvents {
-    NSMutableArray *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
+    NSMutableArray<SUKEvent*> *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
     [mutableArrOfEvents removeAllObjects];
     self.arrOfEvents = mutableArrOfEvents;
     
@@ -102,22 +102,20 @@
         if(events.count == 0) {
             [strongSelf.tableView reloadData];
             [strongSelf.refreshControl endRefreshing];
-            //[self.spinner stopAnimating]; Commented out code
-        }
-        
-        for(PFUser *event in events) {
-            NSMutableArray *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
-            [mutableArrOfEvents addObject:event];
+        } else {
+            NSMutableArray<SUKEvent*> *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
+            for(SUKEvent *event in events) {
+                [mutableArrOfEvents addObject:event];
+            }
             strongSelf.arrOfEvents = [mutableArrOfEvents copy];
             [strongSelf.tableView reloadData];
             [strongSelf.refreshControl endRefreshing];
-            //[self.spinner stopAnimating]; Commented out code
         }
     }];
 }
 
 - (void) registeredEvents {
-    NSMutableArray *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
+    NSMutableArray<SUKEvent*> *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
     [mutableArrOfEvents removeAllObjects];
     self.arrOfEvents = mutableArrOfEvents;
     
@@ -134,15 +132,14 @@
         if(events.count == 0) {
             [strongSelf.tableView reloadData];
             [strongSelf.refreshControl endRefreshing];
-            //[self.spinner stopAnimating]; Commented out code
-        }
-        for(PFUser *event in events) {
-            NSMutableArray *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
-            [mutableArrOfEvents addObject:event];
+        } else {
+            NSMutableArray<SUKEvent*> *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
+            for(SUKEvent *event in events) {
+                [mutableArrOfEvents addObject:event];
+            }
             strongSelf.arrOfEvents = [mutableArrOfEvents copy];
             [strongSelf.tableView reloadData];
             [strongSelf.refreshControl endRefreshing];
-            //[self.spinner stopAnimating]; Commented out code
         }
     }];
 }
@@ -155,8 +152,7 @@
 
 -(UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath{
     SUKBrowseEventTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"SUKBrowseEventTableViewCell"];
-    SUKEvent *eventToDisplay = self.arrOfEvents[indexPath.row];
-    [cell setEvent:eventToDisplay];
+    [cell setEvent:self.arrOfEvents[indexPath.row]];
     cell.delegate = self;
     return cell;
 }
@@ -165,8 +161,7 @@
     if([segue.identifier isEqualToString:@"BrowseEventsToEventDetailsSegue"]) {
         NSIndexPath *indexPath = [self.tableView indexPathForCell: (SUKBrowseEventTableViewCell*) sender];
         SUKEventDetailsViewController *eventDetailsVC = [segue destinationViewController];
-        SUKEvent *event = self.arrOfEvents[indexPath.row];
-        [eventDetailsVC setEvent:event];
+        [eventDetailsVC setEvent:self.arrOfEvents[indexPath.row]];
     }
 }
 

--- a/Suko/View Controller/SUKBrowseEventViewController.m
+++ b/Suko/View Controller/SUKBrowseEventViewController.m
@@ -16,6 +16,7 @@
 @property (nonatomic, strong) NSArray<SUKEvent*> *arrOfEvents;
 @property (nonatomic, strong) UIRefreshControl *refreshControl;
 @property (nonatomic, strong) CLLocationManager *locationManager;
+@property (weak, nonatomic) IBOutlet UISegmentedControl *discoverRegisteredSegmentedControl;
 
 @end
 
@@ -29,7 +30,7 @@
     self.tableView.rowHeight = UITableViewAutomaticDimension;
     
     self.refreshControl = [[UIRefreshControl alloc] init];
-    [self.refreshControl addTarget:self action:@selector(events) forControlEvents:UIControlEventValueChanged];
+    [self.refreshControl addTarget:self action:@selector(refreshData) forControlEvents:UIControlEventValueChanged];
     [self.tableView insertSubview:self.refreshControl atIndex:0];
     
     self.arrOfEvents = [[NSArray alloc] init];
@@ -44,7 +45,7 @@
 
     [self.locationManager startUpdatingLocation];
     
-    [self events];
+    [self browseEvents];
 }
 
 - (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations {
@@ -55,7 +56,19 @@
     [self.locationManager stopUpdatingLocation];
 }
 
-- (void)events {
+- (void) refreshData {
+    if(self.discoverRegisteredSegmentedControl.selectedSegmentIndex == 0) {
+        [self browseEvents];
+    } else {
+        [self registeredEvents];
+    }
+}
+
+- (IBAction)segmentChanged:(id)sender {
+    [self refreshData];
+}
+
+- (void)browseEvents {
     NSMutableArray *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
     [mutableArrOfEvents removeAllObjects];
     self.arrOfEvents = mutableArrOfEvents;
@@ -67,6 +80,37 @@
     [query whereKey:@"endTime" greaterThan:[NSDate now]];
     
     [query findObjectsInBackgroundWithBlock:^(NSArray<SUKEvent *> *events, NSError *error) {
+        if(events.count == 0) {
+            [self.tableView reloadData];
+            [self.refreshControl endRefreshing];
+        }
+        for(PFUser *event in events) {
+            NSMutableArray *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
+            [mutableArrOfEvents addObject:event];
+            self.arrOfEvents = [mutableArrOfEvents copy];
+            [self.tableView reloadData];
+            [self.refreshControl endRefreshing];
+        }
+    }];
+}
+
+- (void) registeredEvents {
+    NSMutableArray *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
+    [mutableArrOfEvents removeAllObjects];
+    self.arrOfEvents = mutableArrOfEvents;
+    
+    PFQuery *query = [PFQuery queryWithClassName:@"SUKEvent"];
+    [query includeKey:@"location"];
+    [query whereKey:@"location" nearGeoPoint:[PFUser currentUser][@"current_coordinates"] withinMiles:5.0];
+    [query whereKey:@"endTime" greaterThan:[NSDate now]];
+    NSString *currentUserID = [PFUser currentUser].objectId;
+    [query whereKey:@"attendees" containsAllObjectsInArray:@[currentUserID]];
+    
+    [query findObjectsInBackgroundWithBlock:^(NSArray<SUKEvent *> *events, NSError *error) {
+        if(events.count == 0) {
+            [self.tableView reloadData];
+            [self.refreshControl endRefreshing];
+        }
         for(PFUser *event in events) {
             NSMutableArray *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
             [mutableArrOfEvents addObject:event];

--- a/Suko/View Controller/SUKBrowseEventViewController.m
+++ b/Suko/View Controller/SUKBrowseEventViewController.m
@@ -15,7 +15,7 @@
 
 @interface SUKBrowseEventViewController () <UITableViewDataSource, UITableViewDelegate, CLLocationManagerDelegate>
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
-@property (nonatomic, strong) NSArray<SUKEvent*> *arrOfEvents;
+@property (nonatomic, strong) NSArray<SUKEvent *> *arrOfEvents;
 @property (nonatomic, strong) UIRefreshControl *refreshControl;
 @property (nonatomic, strong) CLLocationManager *locationManager;
 @property (weak, nonatomic) IBOutlet UISegmentedControl *discoverRegisteredSegmentedControl;
@@ -51,13 +51,13 @@
     self.spinner.hidesWhenStopped = YES;
 }
 
-- (void) viewWillAppear:(BOOL)animated {
+- (void)viewWillAppear:(BOOL)animated {
     [self refreshData];
 
     [self.spinner startAnimating];
 }
 
-- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation*>*)locations {
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations {
     PFGeoPoint *point = [PFGeoPoint geoPointWithLocation:[locations lastObject]];
     [PFUser currentUser][@"current_coordinates"] = point;
     [[PFUser currentUser] saveInBackground];
@@ -65,7 +65,7 @@
     [self.locationManager stopUpdatingLocation];
 }
 
-- (void) refreshData {
+- (void)refreshData {
     if(self.discoverRegisteredSegmentedControl.selectedSegmentIndex == 0) {
         [self browseEvents];
     } else {
@@ -79,7 +79,7 @@
 }
 
 - (void)browseEvents {
-    NSMutableArray<SUKEvent*> *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
+    NSMutableArray<SUKEvent *> *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
     [mutableArrOfEvents removeAllObjects];
     self.arrOfEvents = mutableArrOfEvents;
     
@@ -98,7 +98,7 @@
             [strongSelf.refreshControl endRefreshing];
             [strongSelf.spinner stopAnimating];
         } else {
-            NSMutableArray<SUKEvent*> *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
+            NSMutableArray<SUKEvent *> *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
             for(SUKEvent *event in events) {
                 [mutableArrOfEvents addObject:event];
             }
@@ -110,7 +110,7 @@
     }];
 }
 
-- (void) registeredEvents {
+- (void)registeredEvents {
     NSMutableArray<SUKEvent*> *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
     [mutableArrOfEvents removeAllObjects];
     self.arrOfEvents = mutableArrOfEvents;
@@ -132,7 +132,7 @@
             [strongSelf.refreshControl endRefreshing];
             [strongSelf.spinner stopAnimating];
         } else {
-            NSMutableArray<SUKEvent*> *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
+            NSMutableArray<SUKEvent *> *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
             for(SUKEvent *event in events) {
                 [mutableArrOfEvents addObject:event];
             }
@@ -146,11 +146,11 @@
 
 #pragma mark - TableView
 
--(NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section{
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     return self.arrOfEvents.count;
 }
 
--(UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath{
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     SUKBrowseEventTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"SUKBrowseEventTableViewCell"];
     [cell setEvent:self.arrOfEvents[indexPath.row]];
     return cell;

--- a/Suko/View Controller/SUKBrowseEventViewController.m
+++ b/Suko/View Controller/SUKBrowseEventViewController.m
@@ -94,10 +94,12 @@
     [query findObjectsInBackgroundWithBlock:^(NSArray<SUKEvent *> *events, NSError *error) {
         __strong __typeof(self) strongSelf = weakSelf;
         if(events.count == 0) {
+            [strongSelf emptyTableView];
             [strongSelf.tableView reloadData];
             [strongSelf.refreshControl endRefreshing];
             [strongSelf.spinner stopAnimating];
         } else {
+            [strongSelf restoreTableViewFromEmptyState];
             NSMutableArray<SUKEvent *> *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
             for(SUKEvent *event in events) {
                 [mutableArrOfEvents addObject:event];
@@ -128,10 +130,12 @@
     [query findObjectsInBackgroundWithBlock:^(NSArray<SUKEvent *> *events, NSError *error) {
         __strong __typeof(self) strongSelf = weakSelf;
         if(events.count == 0) {
+            [strongSelf emptyTableView];
             [strongSelf.tableView reloadData];
             [strongSelf.refreshControl endRefreshing];
             [strongSelf.spinner stopAnimating];
         } else {
+            [strongSelf restoreTableViewFromEmptyState];
             NSMutableArray<SUKEvent *> *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
             for(SUKEvent *event in events) {
                 [mutableArrOfEvents addObject:event];
@@ -155,6 +159,29 @@
     [cell setEvent:self.arrOfEvents[indexPath.row]];
     return cell;
 }
+
+- (void)emptyTableView {
+    UILabel *emptyListMessageLabel = [[UILabel alloc] initWithFrame:CGRectMake(40, 70, self.tableView.bounds.size.width/2, self.tableView.bounds.size.height/2)];
+    emptyListMessageLabel.backgroundColor = [UIColor clearColor];
+    emptyListMessageLabel.textAlignment = NSTextAlignmentCenter;
+    emptyListMessageLabel.textColor = [UIColor blackColor];
+    emptyListMessageLabel.numberOfLines = 0;
+    emptyListMessageLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    if(self.discoverRegisteredSegmentedControl.selectedSegmentIndex == 0) {
+        emptyListMessageLabel.text = @"No events within 5 miles of you.";
+    } else {
+        emptyListMessageLabel.text = @"No registered events yet.";
+    }
+    self.tableView.backgroundView = emptyListMessageLabel;
+    self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+}
+
+- (void)restoreTableViewFromEmptyState {
+    self.tableView.backgroundView = nil;
+    self.tableView.separatorStyle = UITableViewCellSeparatorStyleSingleLine;
+}
+
+#pragma mark - Navigation
 
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
     if([segue.identifier isEqualToString:@"BrowseEventsToEventDetailsSegue"]) {

--- a/Suko/View Controller/SUKBrowseEventViewController.m
+++ b/Suko/View Controller/SUKBrowseEventViewController.m
@@ -133,7 +133,6 @@
     SUKBrowseEventTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"SUKBrowseEventTableViewCell"];
     SUKEvent *eventToDisplay = self.arrOfEvents[indexPath.row];
     [cell setEvent:eventToDisplay];
-    cell.poster = eventToDisplay.postedBy;
     return cell;
 }
 

--- a/Suko/View Controller/SUKBrowseEventViewController.m
+++ b/Suko/View Controller/SUKBrowseEventViewController.m
@@ -81,17 +81,19 @@
     [query whereKey:@"location" nearGeoPoint:[PFUser currentUser][@"current_coordinates"] withinMiles:5.0];
     [query whereKey:@"endTime" greaterThan:[NSDate now]];
     
+    __weak __typeof(self) weakSelf = self;
     [query findObjectsInBackgroundWithBlock:^(NSArray<SUKEvent *> *events, NSError *error) {
+        __strong __typeof(self) strongSelf = weakSelf;
         if(events.count == 0) {
-            [self.tableView reloadData];
-            [self.refreshControl endRefreshing];
+            [strongSelf.tableView reloadData];
+            [strongSelf.refreshControl endRefreshing];
         }
         for(PFUser *event in events) {
             NSMutableArray *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
             [mutableArrOfEvents addObject:event];
-            self.arrOfEvents = [mutableArrOfEvents copy];
-            [self.tableView reloadData];
-            [self.refreshControl endRefreshing];
+            strongSelf.arrOfEvents = [mutableArrOfEvents copy];
+            [strongSelf.tableView reloadData];
+            [strongSelf.refreshControl endRefreshing];
         }
     }];
 }
@@ -108,17 +110,19 @@
     NSString *currentUserID = [PFUser currentUser].objectId;
     [query whereKey:@"attendees" containsAllObjectsInArray:@[currentUserID]];
     
+    __weak __typeof(self) weakSelf = self;
     [query findObjectsInBackgroundWithBlock:^(NSArray<SUKEvent *> *events, NSError *error) {
+        __strong __typeof(self) strongSelf = weakSelf;
         if(events.count == 0) {
-            [self.tableView reloadData];
-            [self.refreshControl endRefreshing];
+            [strongSelf.tableView reloadData];
+            [strongSelf.refreshControl endRefreshing];
         }
         for(PFUser *event in events) {
             NSMutableArray *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
             [mutableArrOfEvents addObject:event];
-            self.arrOfEvents = [mutableArrOfEvents copy];
-            [self.tableView reloadData];
-            [self.refreshControl endRefreshing];
+            strongSelf.arrOfEvents = [mutableArrOfEvents copy];
+            [strongSelf.tableView reloadData];
+            [strongSelf.refreshControl endRefreshing];
         }
     }];
 }

--- a/Suko/View Controller/SUKBrowseEventViewController.m
+++ b/Suko/View Controller/SUKBrowseEventViewController.m
@@ -49,6 +49,8 @@
     [self.locationManager startUpdatingLocation];
     
     self.spinner.hidesWhenStopped = YES;
+    self.spinner.layer.cornerRadius = 10;
+    [self.spinner setCenter:CGPointMake(self.view.bounds.size.width/2.0, self.view.bounds.size.height/2.0)];
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/Suko/View Controller/SUKBrowseEventViewController.m
+++ b/Suko/View Controller/SUKBrowseEventViewController.m
@@ -13,12 +13,13 @@
 #import "SUKNotCurrentUserProfileViewController.h"
 #import "Parse/Parse.h"
 
-@interface SUKBrowseEventViewController () <UITableViewDataSource, UITableViewDelegate, CLLocationManagerDelegate>
+@interface SUKBrowseEventViewController () <UITableViewDataSource, UITableViewDelegate, CLLocationManagerDelegate, SUKBrowseEventTableViewCellDelegate>
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
 @property (nonatomic, strong) NSArray<SUKEvent*> *arrOfEvents;
 @property (nonatomic, strong) UIRefreshControl *refreshControl;
 @property (nonatomic, strong) CLLocationManager *locationManager;
 @property (weak, nonatomic) IBOutlet UISegmentedControl *discoverRegisteredSegmentedControl;
+@property (weak, nonatomic) IBOutlet UIActivityIndicatorView *spinner;
 
 @end
 
@@ -46,10 +47,14 @@
         [self.locationManager requestWhenInUseAuthorization];
 
     [self.locationManager startUpdatingLocation];
+    
+    self.spinner.hidesWhenStopped = YES;
 }
 
 - (void) viewWillAppear:(BOOL)animated {
     [self refreshData];
+
+    [self.spinner startAnimating];
 }
 
 - (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations {
@@ -70,6 +75,14 @@
 
 - (IBAction)segmentChanged:(id)sender {
     [self refreshData];
+    [self.spinner startAnimating];
+}
+
+- (void)profileDoneLoading:(SUKBrowseEventTableViewCell *) cell {
+    NSInteger row = [self.tableView indexPathForCell:cell].row;
+    if(row == self.arrOfEvents.count - 1) {
+        [self.spinner stopAnimating];
+    }
 }
 
 - (void)browseEvents {
@@ -89,13 +102,16 @@
         if(events.count == 0) {
             [strongSelf.tableView reloadData];
             [strongSelf.refreshControl endRefreshing];
+            //[self.spinner stopAnimating]; Commented out code
         }
+        
         for(PFUser *event in events) {
             NSMutableArray *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
             [mutableArrOfEvents addObject:event];
             strongSelf.arrOfEvents = [mutableArrOfEvents copy];
             [strongSelf.tableView reloadData];
             [strongSelf.refreshControl endRefreshing];
+            //[self.spinner stopAnimating]; Commented out code
         }
     }];
 }
@@ -118,6 +134,7 @@
         if(events.count == 0) {
             [strongSelf.tableView reloadData];
             [strongSelf.refreshControl endRefreshing];
+            //[self.spinner stopAnimating]; Commented out code
         }
         for(PFUser *event in events) {
             NSMutableArray *mutableArrOfEvents = [self.arrOfEvents mutableCopy];
@@ -125,6 +142,7 @@
             strongSelf.arrOfEvents = [mutableArrOfEvents copy];
             [strongSelf.tableView reloadData];
             [strongSelf.refreshControl endRefreshing];
+            //[self.spinner stopAnimating]; Commented out code
         }
     }];
 }
@@ -139,6 +157,7 @@
     SUKBrowseEventTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"SUKBrowseEventTableViewCell"];
     SUKEvent *eventToDisplay = self.arrOfEvents[indexPath.row];
     [cell setEvent:eventToDisplay];
+    cell.delegate = self;
     return cell;
 }
 

--- a/Suko/View Controller/SUKBrowseEventViewController.m
+++ b/Suko/View Controller/SUKBrowseEventViewController.m
@@ -7,9 +7,11 @@
 
 #import "SUKBrowseEventViewController.h"
 #import "SUKEvent.h"
-#import "SUKEventTableViewCell.h"
+#import "SUKBrowseEventTableViewCell.h"
 #import "SUKEventDetailsViewController.h"
 #import <MapKit/MapKit.h>
+#import "SUKNotCurrentUserProfileViewController.h"
+#import "Parse/Parse.h"
 
 @interface SUKBrowseEventViewController () <UITableViewDataSource, UITableViewDelegate, CLLocationManagerDelegate>
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
@@ -45,7 +47,7 @@
 
     [self.locationManager startUpdatingLocation];
     
-    [self browseEvents];
+    [self refreshData];
 }
 
 - (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations {
@@ -128,16 +130,16 @@
 }
 
 -(UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath{
-    SUKEventTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"SUKEventTableViewCell"];
+    SUKBrowseEventTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"SUKBrowseEventTableViewCell"];
     SUKEvent *eventToDisplay = self.arrOfEvents[indexPath.row];
     [cell setEvent:eventToDisplay];
-    
+    cell.poster = eventToDisplay.postedBy;
     return cell;
 }
 
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
     if([segue.identifier isEqualToString:@"BrowseEventsToEventDetailsSegue"]) {
-        NSIndexPath *indexPath = [self.tableView indexPathForCell: (SUKEventTableViewCell*) sender];
+        NSIndexPath *indexPath = [self.tableView indexPathForCell: (SUKBrowseEventTableViewCell*) sender];
         SUKEventDetailsViewController *eventDetailsVC = [segue destinationViewController];
         SUKEvent *event = self.arrOfEvents[indexPath.row];
         [eventDetailsVC setEvent:event];

--- a/Suko/View Controller/SUKBrowseEventViewController.m
+++ b/Suko/View Controller/SUKBrowseEventViewController.m
@@ -46,7 +46,9 @@
         [self.locationManager requestWhenInUseAuthorization];
 
     [self.locationManager startUpdatingLocation];
-    
+}
+
+- (void) viewWillAppear:(BOOL)animated {
     [self refreshData];
 }
 

--- a/Suko/View Controller/SUKChooseEventLocationViewController.m
+++ b/Suko/View Controller/SUKChooseEventLocationViewController.m
@@ -86,12 +86,14 @@
         CLLocationCoordinate2D eventCoordinate = eventLocationAnnotation.coordinate;
         CLLocation *eventLocation = [[CLLocation alloc] initWithLatitude:eventCoordinate.latitude longitude:eventCoordinate.longitude];
         
+        __weak __typeof(self) weakSelf = self;
         [SUKEvent postEventWithName:self.eventName eventDescription:self.eventDescription eventLocation:eventLocation startTime:self.eventStartDate endTime:self.eventEndDate postedBy:[PFUser currentUser] withCompletion:^(BOOL succeeded, NSError * error) {
+            __strong __typeof(self) strongSelf = weakSelf;
             if (succeeded) {
                 NSLog(@"The event was uploaded!");
                 
                 NSArray *viewControllers = [self.navigationController viewControllers];
-                [self.navigationController popToViewController:viewControllers[0] animated:YES]; // Navigate back to original map VC
+                [strongSelf.navigationController popToViewController:viewControllers[0] animated:YES]; // Navigate back to original map VC
             } else {
                 NSLog(@"Problem uploading the event: %@", error.localizedDescription);
             }

--- a/Suko/View Controller/SUKChooseEventLocationViewController.m
+++ b/Suko/View Controller/SUKChooseEventLocationViewController.m
@@ -37,7 +37,7 @@
     [self.mapView addGestureRecognizer:longPressRecognizer];
 }
 
-- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations {
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation*>*)locations {
     self.currentUserLocation = [locations lastObject];
     
     MKCoordinateRegion currentUserRegion = MKCoordinateRegionMake(self.currentUserLocation.coordinate, MKCoordinateSpanMake(0.01, 0.01));
@@ -92,7 +92,7 @@
             if (succeeded) {
                 NSLog(@"The event was uploaded!");
                 
-                NSArray *viewControllers = [self.navigationController viewControllers];
+                NSArray<UIViewController*> *viewControllers = [self.navigationController viewControllers];
                 [strongSelf.navigationController popToViewController:viewControllers[0] animated:YES]; // Navigate back to original map VC
             } else {
                 NSLog(@"Problem uploading the event: %@", error.localizedDescription);

--- a/Suko/View Controller/SUKChooseEventLocationViewController.m
+++ b/Suko/View Controller/SUKChooseEventLocationViewController.m
@@ -37,7 +37,7 @@
     [self.mapView addGestureRecognizer:longPressRecognizer];
 }
 
-- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation*>*)locations {
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations {
     self.currentUserLocation = [locations lastObject];
     
     MKCoordinateRegion currentUserRegion = MKCoordinateRegionMake(self.currentUserLocation.coordinate, MKCoordinateSpanMake(0.01, 0.01));
@@ -92,7 +92,7 @@
             if (succeeded) {
                 NSLog(@"The event was uploaded!");
                 
-                NSArray<UIViewController*> *viewControllers = [self.navigationController viewControllers];
+                NSArray<UIViewController *> *viewControllers = [self.navigationController viewControllers];
                 [strongSelf.navigationController popToViewController:viewControllers[0] animated:YES]; // Navigate back to original map VC
             } else {
                 NSLog(@"Problem uploading the event: %@", error.localizedDescription);

--- a/Suko/View Controller/SUKChooseEventLocationViewController.m
+++ b/Suko/View Controller/SUKChooseEventLocationViewController.m
@@ -20,7 +20,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    self.locationManager = [[CLLocationManager alloc] init];
+    self.locationManager = [CLLocationManager new];
     self.locationManager.delegate = self;
     self.locationManager.distanceFilter = kCLDistanceFilterNone;
     self.locationManager.desiredAccuracy = kCLLocationAccuracyBest;

--- a/Suko/View Controller/SUKCreateNewEventViewController.m
+++ b/Suko/View Controller/SUKCreateNewEventViewController.m
@@ -36,11 +36,11 @@
                   forControlEvents:UIControlEventValueChanged];
 }
 
-- (void) startDateChanged:(id)sender{
+- (void)startDateChanged:(id)sender {
     self.endTimeDatePicker.minimumDate = self.startTimeDatePicker.date;
 }
 
--(void)dismissKeyboard{
+- (void)dismissKeyboard {
     [self.eventNameTextField resignFirstResponder];
     [self.eventDescriptionTextView resignFirstResponder];
 }

--- a/Suko/View Controller/SUKDetailsViewController.m
+++ b/Suko/View Controller/SUKDetailsViewController.m
@@ -70,7 +70,7 @@
 }
 
 - (void)dropdownMenu:(MKDropdownMenu *)dropdownMenu didSelectRow:(NSInteger)row inComponent:(NSInteger)component {
-    NSMutableArray<NSMutableArray*> *currentAllData = [PFUser currentUser][@"list_data"];
+    NSMutableArray<NSMutableArray *> *currentAllData = [PFUser currentUser][@"list_data"];
     NSNumber *malID = [NSNumber numberWithInt:self.animeToDisplay.malID];
     
     if(row == 0) { // User clicked on "remove from lists"

--- a/Suko/View Controller/SUKDetailsViewController.m
+++ b/Suko/View Controller/SUKDetailsViewController.m
@@ -32,7 +32,7 @@
     self.titleLabel.text = self.animeToDisplay.title;
     self.synopsisLabel.text = self.animeToDisplay.synopsis;
     
-    NSString *numOfEpString = [NSString stringWithFormat:@"%d", self.animeToDisplay.episodes];
+    NSString *numOfEpString = [NSString stringWithFormat:@"%d", self.animeToDisplay.numEpisodes];
     self.numOfEpLabel.text = [numOfEpString stringByAppendingString:@" Episodes"];
     
     self.listOptions = @[@"Remove from lists", @"Want to Watch", @"Watching", @"Watched"];

--- a/Suko/View Controller/SUKEditProfileViewController.m
+++ b/Suko/View Controller/SUKEditProfileViewController.m
@@ -23,7 +23,7 @@
     [self loadViewContents];
 }
 
-- (void) loadViewContents {
+- (void)loadViewContents {
     // Load username
     self.usernameTextField.text = [PFUser currentUser].username;
     

--- a/Suko/View Controller/SUKEventDetailsViewController.h
+++ b/Suko/View Controller/SUKEventDetailsViewController.h
@@ -13,6 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SUKEventDetailsViewController : UIViewController
 @property (nonatomic, strong) SUKEvent *event;
 
+- (void) setEvent:(SUKEvent*) event withHost:(PFUser *) user;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Suko/View Controller/SUKEventDetailsViewController.h
+++ b/Suko/View Controller/SUKEventDetailsViewController.h
@@ -12,9 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SUKEventDetailsViewController : UIViewController
 @property (nonatomic, strong) SUKEvent *event;
-
-- (void) setEvent:(SUKEvent*) event withHost:(PFUser *) user;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Suko/View Controller/SUKEventDetailsViewController.h
+++ b/Suko/View Controller/SUKEventDetailsViewController.h
@@ -12,6 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SUKEventDetailsViewController : UIViewController
 @property (nonatomic, strong) SUKEvent *event;
+
+extern NSString *const kEventDetailsToNotCurrentUserProfileSegue;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Suko/View Controller/SUKEventDetailsViewController.m
+++ b/Suko/View Controller/SUKEventDetailsViewController.m
@@ -19,6 +19,7 @@
 @property (weak, nonatomic) IBOutlet PFImageView *profileImageView;
 @property (weak, nonatomic) IBOutlet UILabel *decriptionLabel;
 @property (weak, nonatomic) IBOutlet UIButton *registerButton;
+@property (weak, nonatomic) IBOutlet UIActivityIndicatorView *spinner;
 
 @end
 
@@ -36,6 +37,9 @@
     
     self.registerButton.layer.cornerRadius = 4;
     self.registerButton.layer.masksToBounds = true;
+    
+    self.spinner.hidesWhenStopped = YES;
+    [self.spinner startAnimating];
 }
 
 - (void) didTapUserProfile:(UITapGestureRecognizer *)sender{
@@ -85,6 +89,10 @@
                 } else {
                     [strongSelf.registerButton setTitle:@"Register" forState:UIControlStateNormal];
                 }
+                
+                [self.spinner stopAnimating];
+            } else {
+                NSLog(@"%@", error.localizedDescription);
             }
         }];
     }];

--- a/Suko/View Controller/SUKEventDetailsViewController.m
+++ b/Suko/View Controller/SUKEventDetailsViewController.m
@@ -63,21 +63,24 @@
                                 stringByAppendingString:@" - "]
                                stringByAppendingString:[dateFormatter stringFromDate:event.endTime]];
         
-        PFUser *eventPoster = event.postedBy;
-        [eventPoster fetchIfNeeded];
-        self.usernameLabel.text = eventPoster.username;
-        
-        self.profileImageView.file = eventPoster[@"profile_image"];
-        [self.profileImageView loadInBackground];
-        self.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.height /2;
-        self.profileImageView.layer.masksToBounds = YES;
-        self.profileImageView.layer.borderWidth = 0;
-        
-        if([self.event[@"attendees"] containsObject:[PFUser currentUser].objectId]) {
-            [self.registerButton setTitle:@"Registered" forState:UIControlStateNormal];
-        } else {
-            [self.registerButton setTitle:@"Register" forState:UIControlStateNormal];
-        }
+        [event.postedBy fetchInBackgroundWithBlock:^(PFObject * _Nullable object, NSError * _Nullable error) {
+            if(object != nil) {
+                PFUser *eventPoster = (PFUser *) object;
+                self.usernameLabel.text = eventPoster.username;
+                
+                self.profileImageView.file = eventPoster[@"profile_image"];
+                [self.profileImageView loadInBackground];
+                self.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.height /2;
+                self.profileImageView.layer.masksToBounds = YES;
+                self.profileImageView.layer.borderWidth = 0;
+                
+                if([self.event[@"attendees"] containsObject:[PFUser currentUser].objectId]) {
+                    [self.registerButton setTitle:@"Registered" forState:UIControlStateNormal];
+                } else {
+                    [self.registerButton setTitle:@"Register" forState:UIControlStateNormal];
+                }
+            }
+        }];
     }];
 }
 

--- a/Suko/View Controller/SUKEventDetailsViewController.m
+++ b/Suko/View Controller/SUKEventDetailsViewController.m
@@ -25,6 +25,8 @@
 
 @implementation SUKEventDetailsViewController
 
+NSString *const kEventDetailsToNotCurrentUserProfileSegue = @"EventDetailsToNotCurrentUserProfileSegue";
+
 - (void)viewDidLoad {
     [super viewDidLoad];
     
@@ -111,11 +113,11 @@
 #pragma mark - Navigation
 
 - (void) didTapUserProfile:(UITapGestureRecognizer *)sender{
-    [self performSegueWithIdentifier:@"EventDetailsToNotCurrentUserProfileSegue" sender:self.event.postedBy];
+    [self performSegueWithIdentifier:kEventDetailsToNotCurrentUserProfileSegue sender:self.event.postedBy];
 }
 
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    if([segue.identifier isEqualToString:@"EventDetailsToNotCurrentUserProfileSegue"]) {
+    if([segue.identifier isEqualToString:kEventDetailsToNotCurrentUserProfileSegue]) {
         SUKNotCurrentUserProfileViewController *notCurrentUserprofileVC = [segue destinationViewController];
         notCurrentUserprofileVC.userToDisplay = sender;
     }

--- a/Suko/View Controller/SUKEventDetailsViewController.m
+++ b/Suko/View Controller/SUKEventDetailsViewController.m
@@ -9,6 +9,7 @@
 #import <CoreLocation/CoreLocation.h>
 #import <Contacts/CNPostalAddressFormatter.h>
 #import <Parse/PFImageView.h>
+#import "SUKNotCurrentUserProfileViewController.h"
 
 @interface SUKEventDetailsViewController ()
 @property (weak, nonatomic) IBOutlet UILabel *eventNameLabel;
@@ -25,6 +26,17 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
+    UITapGestureRecognizer *profileImageTapGestureRecognizer = [[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(didTapUserProfile:)];
+    [self.profileImageView addGestureRecognizer:profileImageTapGestureRecognizer];
+    [self.profileImageView setUserInteractionEnabled:YES];
+    UITapGestureRecognizer *usernameTapGestureRecognizer = [[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(didTapUserProfile:)];
+    [self.usernameLabel setUserInteractionEnabled:YES];
+    [self.usernameLabel addGestureRecognizer:usernameTapGestureRecognizer];
+}
+
+- (void) didTapUserProfile:(UITapGestureRecognizer *)sender{
+    [self performSegueWithIdentifier:@"EventDetailsToNotCurrentUserProfileSegue" sender:self.event.postedBy];
 }
 
 - (void) setEvent:(SUKEvent*) event {
@@ -84,14 +96,14 @@
     [self.event saveInBackground];
 }
 
-/*
+
 #pragma mark - Navigation
 
-// In a storyboard-based application, you will often want to do a little preparation before navigation
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    // Get the new view controller using [segue destinationViewController].
-    // Pass the selected object to the new view controller.
+    if([segue.identifier isEqualToString:@"EventDetailsToNotCurrentUserProfileSegue"]) {
+        SUKNotCurrentUserProfileViewController *notCurrentUserprofileVC = [segue destinationViewController];
+        notCurrentUserprofileVC.userToDisplay = sender;
+    }
 }
-*/
 
 @end

--- a/Suko/View Controller/SUKEventDetailsViewController.m
+++ b/Suko/View Controller/SUKEventDetailsViewController.m
@@ -33,6 +33,9 @@
     UITapGestureRecognizer *usernameTapGestureRecognizer = [[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(didTapUserProfile:)];
     [self.usernameLabel setUserInteractionEnabled:YES];
     [self.usernameLabel addGestureRecognizer:usernameTapGestureRecognizer];
+    
+    self.registerButton.layer.cornerRadius = 4;
+    self.registerButton.layer.masksToBounds = true;
 }
 
 - (void) didTapUserProfile:(UITapGestureRecognizer *)sender{

--- a/Suko/View Controller/SUKEventDetailsViewController.m
+++ b/Suko/View Controller/SUKEventDetailsViewController.m
@@ -65,7 +65,7 @@
                 [self.registerButton setTitle:@"Register" forState:UIControlStateNormal];
             }
             
-            NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+            NSDateFormatter *dateFormatter = [NSDateFormatter new];
             dateFormatter.dateFormat = @"MM/dd/yyyy h:mm a";
             self.dateLabel.text = [[[dateFormatter stringFromDate:event.startTime]
                                     stringByAppendingString:@" - "]
@@ -75,13 +75,13 @@
 }
 
 - (void)setAddress {
-    CLGeocoder *geoCoder = [[CLGeocoder alloc] init];
+    CLGeocoder *geoCoder = [CLGeocoder new];
     CLLocation *eventCoordinates = [[CLLocation alloc] initWithLatitude:self.event.location.latitude longitude:self.event.location.longitude];
     
     __weak __typeof(self) weakSelf = self;
     [geoCoder reverseGeocodeLocation:eventCoordinates completionHandler:^(NSArray<CLPlacemark *> * placemarks, NSError * error) {
         __strong __typeof(self) strongSelf = weakSelf;
-        CNPostalAddressFormatter *addressFormatter = [[CNPostalAddressFormatter alloc] init];
+        CNPostalAddressFormatter *addressFormatter = [CNPostalAddressFormatter new];
         NSString *multiLineAddress = [addressFormatter stringFromPostalAddress:placemarks[0].postalAddress];
         NSArray<NSString*> *addressBrokenByLines = [multiLineAddress componentsSeparatedByString:@"\n"];
         NSString *singleLineAddress = [addressBrokenByLines componentsJoinedByString:@" "];

--- a/Suko/View Controller/SUKEventDetailsViewController.m
+++ b/Suko/View Controller/SUKEventDetailsViewController.m
@@ -48,39 +48,42 @@
     CLGeocoder *geoCoder = [[CLGeocoder alloc] init];
     CLLocation *eventCoordinates = [[CLLocation alloc] initWithLatitude:event.location.latitude longitude:event.location.longitude];
     
+    __weak __typeof(self) weakSelf = self;
     [geoCoder reverseGeocodeLocation:eventCoordinates completionHandler:^(NSArray<CLPlacemark *> * placemarks, NSError * error) {
+        __strong __typeof(self) strongSelf = weakSelf;
         CNPostalAddressFormatter *addressFormatter = [[CNPostalAddressFormatter alloc] init];
         NSString *multiLineAddress = [addressFormatter stringFromPostalAddress:placemarks[0].postalAddress];
         NSArray *addressBrokenByLines = [multiLineAddress componentsSeparatedByString:@"\n"];
         NSString *singleLineAddress = [addressBrokenByLines componentsJoinedByString:@" "];
 
-        self.addressLabel.text = singleLineAddress;
+        strongSelf.addressLabel.text = singleLineAddress;
         
-        self.eventNameLabel.text = event.name;
+        strongSelf.eventNameLabel.text = event.name;
         
-        self.decriptionLabel.text = event.eventDescription;
+        strongSelf.decriptionLabel.text = event.eventDescription;
         
         NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
         dateFormatter.dateFormat = @"MM/dd/yyyy h:mm a";
-        self.dateLabel.text = [[[dateFormatter stringFromDate:event.startTime]
+        strongSelf.dateLabel.text = [[[dateFormatter stringFromDate:event.startTime]
                                 stringByAppendingString:@" - "]
                                stringByAppendingString:[dateFormatter stringFromDate:event.endTime]];
         
         [event.postedBy fetchInBackgroundWithBlock:^(PFObject * _Nullable object, NSError * _Nullable error) {
+            __strong __typeof(self) strongSelf = weakSelf;
             if(object != nil) {
                 PFUser *eventPoster = (PFUser *) object;
-                self.usernameLabel.text = eventPoster.username;
+                strongSelf.usernameLabel.text = eventPoster.username;
                 
-                self.profileImageView.file = eventPoster[@"profile_image"];
-                [self.profileImageView loadInBackground];
-                self.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.height /2;
-                self.profileImageView.layer.masksToBounds = YES;
-                self.profileImageView.layer.borderWidth = 0;
+                strongSelf.profileImageView.file = eventPoster[@"profile_image"];
+                [strongSelf.profileImageView loadInBackground];
+                strongSelf.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.height /2;
+                strongSelf.profileImageView.layer.masksToBounds = YES;
+                strongSelf.profileImageView.layer.borderWidth = 0;
                 
-                if([self.event[@"attendees"] containsObject:[PFUser currentUser].objectId]) {
-                    [self.registerButton setTitle:@"Registered" forState:UIControlStateNormal];
+                if([strongSelf.event[@"attendees"] containsObject:[PFUser currentUser].objectId]) {
+                    [strongSelf.registerButton setTitle:@"Registered" forState:UIControlStateNormal];
                 } else {
-                    [self.registerButton setTitle:@"Register" forState:UIControlStateNormal];
+                    [strongSelf.registerButton setTitle:@"Register" forState:UIControlStateNormal];
                 }
             }
         }];

--- a/Suko/View Controller/SUKEventDetailsViewController.m
+++ b/Suko/View Controller/SUKEventDetailsViewController.m
@@ -57,13 +57,11 @@
         __strong __typeof(self) strongSelf = weakSelf;
         CNPostalAddressFormatter *addressFormatter = [[CNPostalAddressFormatter alloc] init];
         NSString *multiLineAddress = [addressFormatter stringFromPostalAddress:placemarks[0].postalAddress];
-        NSArray *addressBrokenByLines = [multiLineAddress componentsSeparatedByString:@"\n"];
+        NSArray<NSString*> *addressBrokenByLines = [multiLineAddress componentsSeparatedByString:@"\n"];
         NSString *singleLineAddress = [addressBrokenByLines componentsJoinedByString:@" "];
 
         strongSelf.addressLabel.text = singleLineAddress;
-        
         strongSelf.eventNameLabel.text = event.name;
-        
         strongSelf.decriptionLabel.text = event.eventDescription;
         
         NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
@@ -72,34 +70,26 @@
                                 stringByAppendingString:@" - "]
                                stringByAppendingString:[dateFormatter stringFromDate:event.endTime]];
         
-        [event.postedBy fetchInBackgroundWithBlock:^(PFObject * _Nullable object, NSError * _Nullable error) {
-            __strong __typeof(self) strongSelf = weakSelf;
-            if(object != nil) {
-                PFUser *eventPoster = (PFUser *) object;
-                strongSelf.usernameLabel.text = eventPoster.username;
-                
-                strongSelf.profileImageView.file = eventPoster[@"profile_image"];
-                [strongSelf.profileImageView loadInBackground];
-                strongSelf.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.height /2;
-                strongSelf.profileImageView.layer.masksToBounds = YES;
-                strongSelf.profileImageView.layer.borderWidth = 0;
-                
-                if([strongSelf.event[@"attendees"] containsObject:[PFUser currentUser].objectId]) {
-                    [strongSelf.registerButton setTitle:@"Registered" forState:UIControlStateNormal];
-                } else {
-                    [strongSelf.registerButton setTitle:@"Register" forState:UIControlStateNormal];
-                }
-                
-                [self.spinner stopAnimating];
-            } else {
-                NSLog(@"%@", error.localizedDescription);
-            }
-        }];
+        strongSelf.usernameLabel.text = event.postedBy.username;
+        
+        strongSelf.profileImageView.file = event.postedBy[@"profile_image"];
+        [strongSelf.profileImageView loadInBackground];
+        strongSelf.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.height /2;
+        strongSelf.profileImageView.layer.masksToBounds = YES;
+        strongSelf.profileImageView.layer.borderWidth = 0;
+        
+        if([strongSelf.event[@"attendees"] containsObject:[PFUser currentUser].objectId]) {
+            [strongSelf.registerButton setTitle:@"Registered" forState:UIControlStateNormal];
+        } else {
+            [strongSelf.registerButton setTitle:@"Register" forState:UIControlStateNormal];
+        }
+        
+        [strongSelf.spinner stopAnimating];
     }];
 }
 
 - (IBAction)tapRegister:(id)sender {
-    NSMutableArray *attendeesMutable = [self.event.attendees mutableCopy];
+    NSMutableArray<NSString*> *attendeesMutable = [self.event.attendees mutableCopy];
     
     if([self.event[@"attendees"] containsObject:[PFUser currentUser].objectId]) {
         [attendeesMutable removeObject:[PFUser currentUser].objectId];

--- a/Suko/View Controller/SUKEventDetailsViewController.m
+++ b/Suko/View Controller/SUKEventDetailsViewController.m
@@ -44,7 +44,7 @@ NSString *const kEventDetailsToNotCurrentUserProfileSegue = @"EventDetailsToNotC
     [self.spinner startAnimating];
 }
 
-- (void) setEvent:(SUKEvent*) event {
+- (void)setEvent:(SUKEvent *)event {
     _event = event;
     
     __weak __typeof(self) weakSelf = self;
@@ -85,7 +85,7 @@ NSString *const kEventDetailsToNotCurrentUserProfileSegue = @"EventDetailsToNotC
         __strong __typeof(self) strongSelf = weakSelf;
         CNPostalAddressFormatter *addressFormatter = [CNPostalAddressFormatter new];
         NSString *multiLineAddress = [addressFormatter stringFromPostalAddress:placemarks[0].postalAddress];
-        NSArray<NSString*> *addressBrokenByLines = [multiLineAddress componentsSeparatedByString:@"\n"];
+        NSArray<NSString *> *addressBrokenByLines = [multiLineAddress componentsSeparatedByString:@"\n"];
         NSString *singleLineAddress = [addressBrokenByLines componentsJoinedByString:@" "];
 
         strongSelf.addressLabel.text = singleLineAddress;
@@ -95,7 +95,7 @@ NSString *const kEventDetailsToNotCurrentUserProfileSegue = @"EventDetailsToNotC
 }
 
 - (IBAction)tapRegister:(id)sender {
-    NSMutableArray<NSString*> *attendeesMutable = [self.event.attendees mutableCopy];
+    NSMutableArray<NSString *> *attendeesMutable = [self.event.attendees mutableCopy];
     
     if([self.event[@"attendees"] containsObject:[PFUser currentUser].objectId]) {
         [attendeesMutable removeObject:[PFUser currentUser].objectId];
@@ -112,7 +112,7 @@ NSString *const kEventDetailsToNotCurrentUserProfileSegue = @"EventDetailsToNotC
 
 #pragma mark - Navigation
 
-- (void) didTapUserProfile:(UITapGestureRecognizer *)sender{
+- (void) didTapUserProfile:(UITapGestureRecognizer *)sender {
     [self performSegueWithIdentifier:kEventDetailsToNotCurrentUserProfileSegue sender:self.event.postedBy];
 }
 

--- a/Suko/View Controller/SUKEventDetailsViewController.m
+++ b/Suko/View Controller/SUKEventDetailsViewController.m
@@ -15,7 +15,7 @@
 @property (weak, nonatomic) IBOutlet UILabel *addressLabel;
 @property (weak, nonatomic) IBOutlet UILabel *dateLabel;
 @property (weak, nonatomic) IBOutlet UILabel *usernameLabel;
-@property (weak, nonatomic) IBOutlet PFImageView *userProfileImage;
+@property (weak, nonatomic) IBOutlet PFImageView *profileImageView;
 @property (weak, nonatomic) IBOutlet UILabel *decriptionLabel;
 @property (weak, nonatomic) IBOutlet UIButton *registerButton;
 
@@ -55,11 +55,11 @@
         [eventPoster fetchIfNeeded];
         self.usernameLabel.text = eventPoster.username;
         
-        self.userProfileImage.file = eventPoster[@"profile_image"];
-        [self.userProfileImage loadInBackground];
-        self.userProfileImage.layer.cornerRadius = self.userProfileImage.frame.size.height /2;
-        self.userProfileImage.layer.masksToBounds = YES;
-        self.userProfileImage.layer.borderWidth = 0;
+        self.profileImageView.file = eventPoster[@"profile_image"];
+        [self.profileImageView loadInBackground];
+        self.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.height /2;
+        self.profileImageView.layer.masksToBounds = YES;
+        self.profileImageView.layer.borderWidth = 0;
         
         if([self.event[@"attendees"] containsObject:[PFUser currentUser].objectId]) {
             [self.registerButton setTitle:@"Registered" forState:UIControlStateNormal];

--- a/Suko/View Controller/SUKHomeViewController.h
+++ b/Suko/View Controller/SUKHomeViewController.h
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const kHomeToAnimeListSegueIdentifier;
 extern NSString *const kHomeCollectionCellToDetailsSegueIdentifier;
+extern NSNumber *const kNumOfRows;
 
 @end
 

--- a/Suko/View Controller/SUKHomeViewController.h
+++ b/Suko/View Controller/SUKHomeViewController.h
@@ -11,6 +11,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SUKHomeViewController : UIViewController <UITableViewDataSource, UITableViewDelegate, UICollectionViewDataSource, UICollectionViewDelegate>
 
+extern NSString *const kHomeToAnimeListSegueIdentifier;
+extern NSString *const kHomeCollectionCellToDetailsSegueIdentifier;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Suko/View Controller/SUKHomeViewController.m
+++ b/Suko/View Controller/SUKHomeViewController.m
@@ -45,7 +45,6 @@ NSNumber *const kNumOfRows = @3;
     self.spinner.hidesWhenStopped = YES;
     self.spinner.layer.cornerRadius = 10;
     [self.spinner setCenter:CGPointMake(self.view.bounds.size.width/2.0, self.view.bounds.size.height/2.0)];
-    [self.spinner startAnimating];
     
     self.searchBar.delegate = self;
     self.searchBar.showsCancelButton = true;
@@ -58,8 +57,9 @@ NSNumber *const kNumOfRows = @3;
 - (void)viewWillAppear:(BOOL)animated {
     // If not all desired data have been loaded yet (ex. initial load, used switched to a different tab before all data has loaded)
     if(self.dictOfAnime.count < [kNumOfRows intValue]) {
+        [self.spinner startAnimating];
         [self topAnime];
-        [self genreList:[NSNumber numberWithInt:([kNumOfRows intValue] - 1 - (int)self.dictOfAnime.count)]];
+        [self genreList:[NSNumber numberWithInt:([kNumOfRows intValue] - (int)self.dictOfAnime.count)]];
     }
 }
 

--- a/Suko/View Controller/SUKHomeViewController.m
+++ b/Suko/View Controller/SUKHomeViewController.m
@@ -32,9 +32,9 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    self.dictionaryOfAnime = [[NSMutableDictionary alloc] init];
-    self.dictOfGenres = [[NSMutableDictionary alloc] init];
-    self.headerTitlesBesidesTopAnime = [[NSMutableArray alloc] init];
+    self.dictionaryOfAnime = [NSMutableDictionary new];
+    self.dictOfGenres = [NSMutableDictionary new];
+    self.headerTitlesBesidesTopAnime = [NSMutableArray new];
     
     self.spinner.hidesWhenStopped = YES;
     [self.spinner startAnimating];
@@ -67,7 +67,7 @@
     [[SUKAPIManager shared] fetchAnimeSearchBySearchQuery:searchText completion:^(NSArray<SUKAnime*> *anime, NSError *error) {
         __strong __typeof(self) strongSelf = weakSelf;
         if (anime != nil) {
-            NSMutableDictionary *senderDict = [[NSMutableDictionary alloc] init];
+            NSMutableDictionary *senderDict = [NSMutableDictionary new];
             [senderDict setObject:@"Results" forKey:@"title"];
             [senderDict setObject:anime forKey:@"anime"];
             [strongSelf performSegueWithIdentifier:@"HomeToListSegue" sender:senderDict];
@@ -78,7 +78,7 @@
 }
 
 - (void)segueSUKHomeTableViewCell:(SUKHomeTableViewCell *) cell {
-    NSMutableDictionary *senderDict = [[NSMutableDictionary alloc] init];
+    NSMutableDictionary *senderDict = [NSMutableDictionary new];
     [senderDict setObject:cell.rowHeaderLabel.text forKey:@"title"];
     [senderDict setObject:cell.arrOfAnime forKey:@"anime"];
     [self performSegueWithIdentifier:@"HomeToListSegue" sender:senderDict];
@@ -166,7 +166,7 @@
         __strong __typeof(self) strongSelf = weakSelf;
         if (genres != nil) {
             int maxID = 0;
-            NSMutableArray<NSString*> *arrOfIDs = [[NSMutableArray alloc] init];
+            NSMutableArray<NSString*> *arrOfIDs = [NSMutableArray new];
                         
             for(NSDictionary *genreDict in genres) {
                 if(![genresToNotConsider containsObject:[genreDict valueForKey:@"name"]]) {
@@ -256,7 +256,7 @@
 }
 
 - (NSMutableDictionary *) retriveDataForIndexPathRow: (NSInteger) indexPathRow {
-    NSMutableDictionary *rowData = [[NSMutableDictionary alloc] init];
+    NSMutableDictionary *rowData = [NSMutableDictionary new];
     
     if(indexPathRow == 0) {
         [rowData setObject:@"Top Anime" forKey:@"header"];

--- a/Suko/View Controller/SUKHomeViewController.m
+++ b/Suko/View Controller/SUKHomeViewController.m
@@ -19,9 +19,9 @@
 
 @interface SUKHomeViewController () <SUKHomeTableViewCellDelegate, UISearchBarDelegate>
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
-@property (nonatomic, strong) NSMutableDictionary *dictionaryOfAnime;
-@property (nonatomic, strong) NSMutableDictionary *dictOfGenres;
-@property (nonatomic, strong) NSMutableArray *headerTitlesBesidesTopAnime;
+@property (nonatomic, strong) NSMutableDictionary<NSString*, NSArray<SUKAnime*>*> *dictionaryOfAnime;
+@property (nonatomic, strong) NSMutableDictionary<NSString*, NSString*> *dictOfGenres;
+@property (nonatomic, strong) NSMutableArray<NSString*> *headerTitlesBesidesTopAnime;
 @property (weak, nonatomic) IBOutlet UIActivityIndicatorView *spinner;
 @property (weak, nonatomic) IBOutlet UISearchBar *searchBar;
 
@@ -64,7 +64,7 @@
     
     __weak __typeof(self) weakSelf = self;
     
-    [[SUKAPIManager shared] fetchAnimeSearchBySearchQuery:searchText completion:^(NSArray *anime, NSError *error) {
+    [[SUKAPIManager shared] fetchAnimeSearchBySearchQuery:searchText completion:^(NSArray<SUKAnime*> *anime, NSError *error) {
         __strong __typeof(self) strongSelf = weakSelf;
         if (anime != nil) {
             NSMutableDictionary *senderDict = [[NSMutableDictionary alloc] init];
@@ -113,7 +113,7 @@
 - (void) topAnime {
     [self.spinner startAnimating];
     __weak __typeof(self) weakSelf = self;
-    [[SUKAPIManager shared] fetchTopAnime:^(NSArray *anime, NSError *error) {
+    [[SUKAPIManager shared] fetchTopAnime:^(NSArray<SUKAnime*> *anime, NSError *error) {
         __strong __typeof(self) strongSelf = weakSelf;
         if (anime != nil) {
             NSString *title = @"Top Anime";
@@ -126,13 +126,13 @@
     }];
 }
 
-- (void) genreAnime: (NSMutableArray *) genres {
+- (void) genreAnime: (NSMutableArray<NSString*> *) genres {
     [self.spinner startAnimating];
     NSString *genre = [genres lastObject];
     [genres removeLastObject];
     
     __weak __typeof(self) weakSelf = self;
-    [[SUKAPIManager shared] fetchGenreAnime:genre completion:^(NSArray *anime, NSError *error) {
+    [[SUKAPIManager shared] fetchGenreAnime:genre completion:^(NSArray<SUKAnime*> *anime, NSError *error) {
         __strong __typeof(self) strongSelf = weakSelf;
         if (anime != nil) {
             if(strongSelf.dictOfGenres != nil) {
@@ -162,11 +162,11 @@
 - (void) genreList {
     NSArray<NSString *> *genresToNotConsider = @[@"Ecchi", @"Hentai", @"Erotica"];
     __weak __typeof(self) weakSelf = self;
-    [[SUKAPIManager shared] fetchGenreList:^(NSArray *genres, NSError *error) {
+    [[SUKAPIManager shared] fetchGenreList:^(NSArray<NSDictionary*> *genres, NSError *error) {
         __strong __typeof(self) strongSelf = weakSelf;
         if (genres != nil) {
             int maxID = 0;
-            NSMutableArray *arrOfIDs = [[NSMutableArray alloc] init];
+            NSMutableArray<NSString*> *arrOfIDs = [[NSMutableArray alloc] init];
                         
             for(NSDictionary *genreDict in genres) {
                 if(![genresToNotConsider containsObject:[genreDict valueForKey:@"name"]]) {
@@ -192,7 +192,7 @@
                 randomGenre2 = arc4random_uniform((int)self.dictOfGenres.count);
             }
             
-            NSMutableArray *genres = [@[arrOfIDs[randomGenre1], arrOfIDs[randomGenre2]] mutableCopy];
+            NSMutableArray<NSString*> *genres = [@[arrOfIDs[randomGenre1], arrOfIDs[randomGenre2]] mutableCopy];
             [strongSelf genreAnime:genres];
         } else {
             NSLog(@"%@", error.localizedDescription);
@@ -214,7 +214,7 @@
     NSString *headerTitle = [self retriveDataForIndexPathRow:indexPath.row][@"header"];
     cell.rowHeaderLabel.text = headerTitle;
     
-    NSArray *animeData = [self retriveDataForIndexPathRow:indexPath.row][@"anime"];
+    NSArray<SUKAnime*> *animeData = [self retriveDataForIndexPathRow:indexPath.row][@"anime"];
     cell.arrOfAnime = animeData;
     
     return cell;
@@ -232,7 +232,7 @@
 
 -(NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section{
     NSInteger row = [(SUKHomeCollectionView *)collectionView indexPath].row;
-    NSArray *animeData = [self retriveDataForIndexPathRow:row][@"anime"];
+    NSArray<SUKAnime*> *animeData = [self retriveDataForIndexPathRow:row][@"anime"];
     return animeData.count;
 }
 
@@ -240,7 +240,7 @@
     SUKHomeCollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:@"SUKHomeCollectionViewCell" forIndexPath:indexPath];
     
     NSInteger row = [(SUKHomeCollectionView *)collectionView indexPath].row;
-    NSArray *collectionViewArray = [self retriveDataForIndexPathRow:row][@"anime"];
+    NSArray<SUKAnime*> *collectionViewArray = [self retriveDataForIndexPathRow:row][@"anime"];
     SUKAnime *animeToDisplay =  collectionViewArray[indexPath.item];
     
     [cell setAnime:animeToDisplay];
@@ -249,7 +249,7 @@
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger row = [(SUKHomeCollectionView *)collectionView indexPath].row;
-    NSArray *collectionViewArray = [self retriveDataForIndexPathRow:row][@"anime"];
+    NSArray<SUKAnime*> *collectionViewArray = [self retriveDataForIndexPathRow:row][@"anime"];
     SUKAnime *animeToDisplay =  collectionViewArray[indexPath.item];
     
     [self performSegueWithIdentifier:@"CollectionToDetailsSegue" sender:animeToDisplay];

--- a/Suko/View Controller/SUKHomeViewController.m
+++ b/Suko/View Controller/SUKHomeViewController.m
@@ -24,10 +24,12 @@
 @property (nonatomic, strong) NSMutableArray<NSString*> *headerTitlesBesidesTopAnime;
 @property (weak, nonatomic) IBOutlet UIActivityIndicatorView *spinner;
 @property (weak, nonatomic) IBOutlet UISearchBar *searchBar;
-
 @end
 
 @implementation SUKHomeViewController
+
+NSString *const kHomeToAnimeListSegueIdentifier = @"HomeToAnimeListSegue";
+NSString *const kHomeCollectionCellToDetailsSegueIdentifier = @"HomeCollectionCellToDetailsSegue";
 
 - (void)viewDidLoad {
     [super viewDidLoad];
@@ -70,7 +72,7 @@
             NSMutableDictionary *senderDict = [NSMutableDictionary new];
             [senderDict setObject:@"Results" forKey:@"title"];
             [senderDict setObject:anime forKey:@"anime"];
-            [strongSelf performSegueWithIdentifier:@"HomeToListSegue" sender:senderDict];
+            [strongSelf performSegueWithIdentifier:kHomeToAnimeListSegueIdentifier sender:senderDict];
         } else {
             NSLog(@"%@", error.localizedDescription);
         }
@@ -81,17 +83,17 @@
     NSMutableDictionary *senderDict = [NSMutableDictionary new];
     [senderDict setObject:cell.rowHeaderLabel.text forKey:@"title"];
     [senderDict setObject:cell.arrOfAnime forKey:@"anime"];
-    [self performSegueWithIdentifier:@"HomeToListSegue" sender:senderDict];
+    [self performSegueWithIdentifier:kHomeToAnimeListSegueIdentifier sender:senderDict];
 }
 
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    if([segue.identifier isEqualToString:@"HomeToListSegue"]) {
+    if([segue.identifier isEqualToString:kHomeToAnimeListSegueIdentifier]) {
         SUKAnimeListViewController *animeListVC = [segue destinationViewController];
         animeListVC.listTitle = sender[@"title"];
         animeListVC.arrOfAnime = sender[@"anime"];
     }
 
-    if([segue.identifier isEqualToString:@"CollectionToDetailsSegue"]) {
+    if([segue.identifier isEqualToString:kHomeCollectionCellToDetailsSegueIdentifier]) {
         SUKDetailsViewController *detailsVC = [segue destinationViewController];
         detailsVC.animeToDisplay = sender;
     }
@@ -252,7 +254,7 @@
     NSArray<SUKAnime*> *collectionViewArray = [self retriveDataForIndexPathRow:row][@"anime"];
     SUKAnime *animeToDisplay =  collectionViewArray[indexPath.item];
     
-    [self performSegueWithIdentifier:@"CollectionToDetailsSegue" sender:animeToDisplay];
+    [self performSegueWithIdentifier:kHomeCollectionCellToDetailsSegueIdentifier sender:animeToDisplay];
 }
 
 - (NSMutableDictionary *) retriveDataForIndexPathRow: (NSInteger) indexPathRow {

--- a/Suko/View Controller/SUKHomeViewController.m
+++ b/Suko/View Controller/SUKHomeViewController.m
@@ -19,9 +19,9 @@
 
 @interface SUKHomeViewController () <SUKHomeTableViewCellDelegate, UISearchBarDelegate>
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
-@property (nonatomic, strong) NSMutableDictionary<NSString*, NSArray<SUKAnime*>*> *dictionaryOfAnime;
-@property (nonatomic, strong) NSMutableDictionary<NSString*, NSString*> *dictOfGenres;
-@property (nonatomic, strong) NSMutableArray<NSString*> *headerTitlesBesidesTopAnime;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSArray<SUKAnime *> *> *dictOfAnime;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSString *> *dictOfGenres;
+@property (nonatomic, strong) NSMutableArray<NSString *> *headerTitlesBesidesTopAnime;
 @property (weak, nonatomic) IBOutlet UIActivityIndicatorView *spinner;
 @property (weak, nonatomic) IBOutlet UISearchBar *searchBar;
 @end
@@ -34,7 +34,7 @@ NSString *const kHomeCollectionCellToDetailsSegueIdentifier = @"HomeCollectionCe
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    self.dictionaryOfAnime = [NSMutableDictionary new];
+    self.dictOfAnime = [NSMutableDictionary new];
     self.dictOfGenres = [NSMutableDictionary new];
     self.headerTitlesBesidesTopAnime = [NSMutableArray new];
     
@@ -54,7 +54,7 @@ NSString *const kHomeCollectionCellToDetailsSegueIdentifier = @"HomeCollectionCe
 
 #pragma mark - Navigation
 
-- (void)searchBarCancelButtonClicked:(UISearchBar *)searchBar{
+- (void)searchBarCancelButtonClicked:(UISearchBar *)searchBar {
     [searchBar resignFirstResponder];
     searchBar.text = @"";
 }
@@ -66,7 +66,7 @@ NSString *const kHomeCollectionCellToDetailsSegueIdentifier = @"HomeCollectionCe
     
     __weak __typeof(self) weakSelf = self;
     
-    [[SUKAPIManager shared] fetchAnimeSearchBySearchQuery:searchText completion:^(NSArray<SUKAnime*> *anime, NSError *error) {
+    [[SUKAPIManager shared] fetchAnimeSearchWithSearchQuery:searchText completion:^(NSArray<SUKAnime *> *anime, NSError *error) {
         __strong __typeof(self) strongSelf = weakSelf;
         if (anime != nil) {
             NSMutableDictionary *senderDict = [NSMutableDictionary new];
@@ -92,7 +92,7 @@ NSString *const kHomeCollectionCellToDetailsSegueIdentifier = @"HomeCollectionCe
         animeListVC.listTitle = sender[@"title"];
         animeListVC.arrOfAnime = sender[@"anime"];
     }
-
+    
     if([segue.identifier isEqualToString:kHomeCollectionCellToDetailsSegueIdentifier]) {
         SUKDetailsViewController *detailsVC = [segue destinationViewController];
         detailsVC.animeToDisplay = sender;
@@ -112,14 +112,14 @@ NSString *const kHomeCollectionCellToDetailsSegueIdentifier = @"HomeCollectionCe
 
 #pragma mark - Fetching Data using SUKAPIManager
 
-- (void) topAnime {
+- (void)topAnime {
     [self.spinner startAnimating];
     __weak __typeof(self) weakSelf = self;
-    [[SUKAPIManager shared] fetchTopAnime:^(NSArray<SUKAnime*> *anime, NSError *error) {
+    [[SUKAPIManager shared] fetchTopAnimeList:^(NSArray<SUKAnime *> *anime, NSError *error) {
         __strong __typeof(self) strongSelf = weakSelf;
         if (anime != nil) {
             NSString *title = @"Top Anime";
-            [strongSelf.dictionaryOfAnime setObject:anime forKey:title];
+            [strongSelf.dictOfAnime setObject:anime forKey:title];
             [strongSelf.spinner stopAnimating];
             [strongSelf.tableView reloadData];
         } else {
@@ -128,24 +128,24 @@ NSString *const kHomeCollectionCellToDetailsSegueIdentifier = @"HomeCollectionCe
     }];
 }
 
-- (void) genreAnime: (NSMutableArray<NSString*> *) genres {
+- (void)genreAnime:(NSMutableArray<NSString *> *) genres {
     [self.spinner startAnimating];
     NSString *genre = [genres lastObject];
     [genres removeLastObject];
     
     __weak __typeof(self) weakSelf = self;
-    [[SUKAPIManager shared] fetchGenreAnime:genre completion:^(NSArray<SUKAnime*> *anime, NSError *error) {
+    [[SUKAPIManager shared] fetchAnimeListWithGenre:genre completion:^(NSArray<SUKAnime *> *anime, NSError *error) {
         __strong __typeof(self) strongSelf = weakSelf;
         if (anime != nil) {
             if(strongSelf.dictOfGenres != nil) {
                 NSString *correspondingGenre = [self.dictOfGenres objectForKey:genre];
                 NSString *title = [[@"Most Popular "
                                     stringByAppendingString:correspondingGenre]
-                                    stringByAppendingString:@" Anime"];
+                                   stringByAppendingString:@" Anime"];
                 
                 [strongSelf.headerTitlesBesidesTopAnime addObject:title];
                 
-                [strongSelf.dictionaryOfAnime setObject:anime forKey:title];
+                [strongSelf.dictOfAnime setObject:anime forKey:title];
                 
                 if([genres count] != 0) {
                     [NSThread sleepForTimeInterval:1.0];
@@ -161,15 +161,15 @@ NSString *const kHomeCollectionCellToDetailsSegueIdentifier = @"HomeCollectionCe
     }];
 }
 
-- (void) genreList {
+- (void)genreList {
     NSArray<NSString *> *genresToNotConsider = @[@"Ecchi", @"Hentai", @"Erotica"];
     __weak __typeof(self) weakSelf = self;
-    [[SUKAPIManager shared] fetchGenreList:^(NSArray<NSDictionary*> *genres, NSError *error) {
+    [[SUKAPIManager shared] fetchGenreList:^(NSArray<NSDictionary *> *genres, NSError *error) {
         __strong __typeof(self) strongSelf = weakSelf;
         if (genres != nil) {
             int maxID = 0;
-            NSMutableArray<NSString*> *arrOfIDs = [NSMutableArray new];
-                        
+            NSMutableArray<NSString *> *arrOfIDs = [NSMutableArray new];
+            
             for(NSDictionary *genreDict in genres) {
                 if(![genresToNotConsider containsObject:[genreDict valueForKey:@"name"]]) {
                     NSNumber *malID = [genreDict valueForKey:@"mal_id"];
@@ -190,11 +190,11 @@ NSString *const kHomeCollectionCellToDetailsSegueIdentifier = @"HomeCollectionCe
             
             int randomGenre1 = arc4random_uniform((int)self.dictOfGenres.count);
             int randomGenre2 = arc4random_uniform((int)self.dictOfGenres.count);
-            while(randomGenre2 == randomGenre1) { 
+            while(randomGenre2 == randomGenre1) {
                 randomGenre2 = arc4random_uniform((int)self.dictOfGenres.count);
             }
             
-            NSMutableArray<NSString*> *genres = [@[arrOfIDs[randomGenre1], arrOfIDs[randomGenre2]] mutableCopy];
+            NSMutableArray<NSString *> *genres = [@[arrOfIDs[randomGenre1], arrOfIDs[randomGenre2]] mutableCopy];
             [strongSelf genreAnime:genres];
         } else {
             NSLog(@"%@", error.localizedDescription);
@@ -204,11 +204,11 @@ NSString *const kHomeCollectionCellToDetailsSegueIdentifier = @"HomeCollectionCe
 
 #pragma mark - TableView
 
--(NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section{
-    return [self.dictionaryOfAnime count];
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return [self.dictOfAnime count];
 }
 
--(UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath{
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     static NSString *cellIdentifier = @"SUKHomeTableViewCell";
     SUKHomeTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:cellIdentifier];
     cell.delegate = self;
@@ -216,33 +216,33 @@ NSString *const kHomeCollectionCellToDetailsSegueIdentifier = @"HomeCollectionCe
     NSString *headerTitle = [self retriveDataForIndexPathRow:indexPath.row][@"header"];
     cell.rowHeaderLabel.text = headerTitle;
     
-    NSArray<SUKAnime*> *animeData = [self retriveDataForIndexPathRow:indexPath.row][@"anime"];
+    NSArray<SUKAnime *> *animeData = [self retriveDataForIndexPathRow:indexPath.row][@"anime"];
     cell.arrOfAnime = animeData;
     
     return cell;
 }
 
--(void)tableView:(UITableView *)tableView willDisplayCell:(SUKHomeTableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
+- (void)tableView:(UITableView *)tableView willDisplayCell:(SUKHomeTableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
     [cell setCollectionViewDataSourceDelegate:self indexPath:indexPath];
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *) indexPath {
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
     return 305;
 }
 
 #pragma mark - CollectionView
 
--(NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section{
+- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
     NSInteger row = [(SUKHomeCollectionView *)collectionView indexPath].row;
-    NSArray<SUKAnime*> *animeData = [self retriveDataForIndexPathRow:row][@"anime"];
+    NSArray<SUKAnime *> *animeData = [self retriveDataForIndexPathRow:row][@"anime"];
     return animeData.count;
 }
 
--(UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath{
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath{
     SUKHomeCollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:@"SUKHomeCollectionViewCell" forIndexPath:indexPath];
     
     NSInteger row = [(SUKHomeCollectionView *)collectionView indexPath].row;
-    NSArray<SUKAnime*> *collectionViewArray = [self retriveDataForIndexPathRow:row][@"anime"];
+    NSArray<SUKAnime *> *collectionViewArray = [self retriveDataForIndexPathRow:row][@"anime"];
     SUKAnime *animeToDisplay =  collectionViewArray[indexPath.item];
     
     [cell setAnime:animeToDisplay];
@@ -251,22 +251,22 @@ NSString *const kHomeCollectionCellToDetailsSegueIdentifier = @"HomeCollectionCe
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
     NSInteger row = [(SUKHomeCollectionView *)collectionView indexPath].row;
-    NSArray<SUKAnime*> *collectionViewArray = [self retriveDataForIndexPathRow:row][@"anime"];
+    NSArray<SUKAnime *> *collectionViewArray = [self retriveDataForIndexPathRow:row][@"anime"];
     SUKAnime *animeToDisplay =  collectionViewArray[indexPath.item];
     
     [self performSegueWithIdentifier:kHomeCollectionCellToDetailsSegueIdentifier sender:animeToDisplay];
 }
 
-- (NSMutableDictionary *) retriveDataForIndexPathRow: (NSInteger) indexPathRow {
+- (NSMutableDictionary *)retriveDataForIndexPathRow:(NSInteger)indexPathRow {
     NSMutableDictionary *rowData = [NSMutableDictionary new];
     
     if(indexPathRow == 0) {
         [rowData setObject:@"Top Anime" forKey:@"header"];
-        [rowData setObject:self.dictionaryOfAnime[@"Top Anime"] forKey:@"anime"];
+        [rowData setObject:self.dictOfAnime[@"Top Anime"] forKey:@"anime"];
     } else {
         NSString *title = self.headerTitlesBesidesTopAnime[indexPathRow - 1];
         [rowData setObject:title forKey:@"header"];
-        [rowData setObject:self.dictionaryOfAnime[title] forKey:@"anime"];
+        [rowData setObject:self.dictOfAnime[title] forKey:@"anime"];
     }
     
     return rowData;

--- a/Suko/View Controller/SUKHomeViewController.m
+++ b/Suko/View Controller/SUKHomeViewController.m
@@ -62,12 +62,15 @@
     NSString *searchText = searchBar.text;
     searchBar.text = @"";
     
+    __weak __typeof(self) weakSelf = self;
+    
     [[SUKAPIManager shared] fetchAnimeSearchBySearchQuery:searchText completion:^(NSArray *anime, NSError *error) {
+        __strong __typeof(self) strongSelf = weakSelf;
         if (anime != nil) {
             NSMutableDictionary *senderDict = [[NSMutableDictionary alloc] init];
             [senderDict setObject:@"Results" forKey:@"title"];
             [senderDict setObject:anime forKey:@"anime"];
-            [self performSegueWithIdentifier:@"HomeToDetailsSegue" sender:senderDict];
+            [strongSelf performSegueWithIdentifier:@"HomeToListSegue" sender:senderDict];
         } else {
             NSLog(@"%@", error.localizedDescription);
         }
@@ -78,11 +81,11 @@
     NSMutableDictionary *senderDict = [[NSMutableDictionary alloc] init];
     [senderDict setObject:cell.rowHeaderLabel.text forKey:@"title"];
     [senderDict setObject:cell.arrOfAnime forKey:@"anime"];
-    [self performSegueWithIdentifier:@"HomeToDetailsSegue" sender:senderDict];
+    [self performSegueWithIdentifier:@"HomeToListSegue" sender:senderDict];
 }
 
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    if([segue.identifier isEqualToString:@"HomeToDetailsSegue"]) {
+    if([segue.identifier isEqualToString:@"HomeToListSegue"]) {
         SUKAnimeListViewController *animeListVC = [segue destinationViewController];
         animeListVC.listTitle = sender[@"title"];
         animeListVC.arrOfAnime = sender[@"anime"];
@@ -95,11 +98,13 @@
 }
 
 - (IBAction)didTapLogout:(id)sender {
+    __weak __typeof(self) weakSelf = self;
     [PFUser logOutInBackgroundWithBlock:^(NSError * _Nullable error) {
+        __strong __typeof(self) strongSelf = weakSelf;
         NSLog(@"User log out");
         UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
         SUKLoginViewController *loginVC = [storyboard instantiateViewControllerWithIdentifier:@"LoginVC"];
-        self.view.window.rootViewController = loginVC;
+        strongSelf.view.window.rootViewController = loginVC;
     }];
 }
 
@@ -107,12 +112,14 @@
 
 - (void) topAnime {
     [self.spinner startAnimating];
+    __weak __typeof(self) weakSelf = self;
     [[SUKAPIManager shared] fetchTopAnime:^(NSArray *anime, NSError *error) {
+        __strong __typeof(self) strongSelf = weakSelf;
         if (anime != nil) {
             NSString *title = @"Top Anime";
-            [self.dictionaryOfAnime setObject:anime forKey:title];
-            [self.spinner stopAnimating];
-            [self.tableView reloadData];
+            [strongSelf.dictionaryOfAnime setObject:anime forKey:title];
+            [strongSelf.spinner stopAnimating];
+            [strongSelf.tableView reloadData];
         } else {
             NSLog(@"%@", error.localizedDescription);
         }
@@ -124,34 +131,39 @@
     NSString *genre = [genres lastObject];
     [genres removeLastObject];
     
+    __weak __typeof(self) weakSelf = self;
     [[SUKAPIManager shared] fetchGenreAnime:genre completion:^(NSArray *anime, NSError *error) {
+        __strong __typeof(self) strongSelf = weakSelf;
         if (anime != nil) {
-            if(self.dictOfGenres != nil) {
+            if(strongSelf.dictOfGenres != nil) {
                 NSString *correspondingGenre = [self.dictOfGenres objectForKey:genre];
                 NSString *title = [[@"Most Popular "
                                     stringByAppendingString:correspondingGenre]
                                     stringByAppendingString:@" Anime"];
                 
-                [self.headerTitlesBesidesTopAnime addObject:title];
+                [strongSelf.headerTitlesBesidesTopAnime addObject:title];
                 
-                [self.dictionaryOfAnime setObject:anime forKey:title];
+                [strongSelf.dictionaryOfAnime setObject:anime forKey:title];
                 
                 if([genres count] != 0) {
                     [NSThread sleepForTimeInterval:1.0];
-                    [self genreAnime:genres];
+                    [strongSelf genreAnime:genres];
                 } else {
-                    [self.spinner stopAnimating];
-                    [self.tableView reloadData];
+                    [strongSelf.spinner stopAnimating];
+                    [strongSelf.tableView reloadData];
                 }
             }
+        } else {
+            NSLog(@"%@", error.localizedDescription);
         }
-        NSLog(@"%@", error.localizedDescription);
     }];
 }
 
 - (void) genreList {
     NSArray<NSString *> *genresToNotConsider = @[@"Ecchi", @"Hentai", @"Erotica"];
+    __weak __typeof(self) weakSelf = self;
     [[SUKAPIManager shared] fetchGenreList:^(NSArray *genres, NSError *error) {
+        __strong __typeof(self) strongSelf = weakSelf;
         if (genres != nil) {
             int maxID = 0;
             NSMutableArray *arrOfIDs = [[NSMutableArray alloc] init];
@@ -170,7 +182,7 @@
                     
                     NSString *genreName = [genreDict valueForKey:@"name"];
                     
-                    [self.dictOfGenres setObject:genreName forKey:malIDString];
+                    [strongSelf.dictOfGenres setObject:genreName forKey:malIDString];
                 }
             }
             
@@ -181,7 +193,7 @@
             }
             
             NSMutableArray *genres = [@[arrOfIDs[randomGenre1], arrOfIDs[randomGenre2]] mutableCopy];
-            [self genreAnime:genres];
+            [strongSelf genreAnime:genres];
         } else {
             NSLog(@"%@", error.localizedDescription);
         }

--- a/Suko/View Controller/SUKHomeViewController.m
+++ b/Suko/View Controller/SUKHomeViewController.m
@@ -166,7 +166,7 @@ NSNumber *const kNumOfRows = @3;
     NSArray<NSString *> *genresToNotConsider = @[@"Ecchi", @"Hentai", @"Erotica"];
     
     __weak __typeof(self) weakSelf = self;
-    [[SUKAPIManager shared] fetchGenreList:^(NSArray<NSDictionary *> *genres, NSError *error) {
+    [[SUKAPIManager shared] fetchAnimeGenreList:^(NSArray<NSDictionary *> *genres, NSError *error) {
         __strong __typeof(self) strongSelf = weakSelf;
         if (genres != nil) {
             NSMutableArray<NSString *> *arrOfGenreIDs = [NSMutableArray new]; // Used to choose random genreIDs later

--- a/Suko/View Controller/SUKHomeViewController.m
+++ b/Suko/View Controller/SUKHomeViewController.m
@@ -42,11 +42,9 @@
     [self topAnime];
     [self genreList];
     
-    // Setting up search bar
     self.searchBar.delegate = self;
     self.searchBar.showsCancelButton = true;
-        
-    // Set up TableView
+    
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     self.tableView.rowHeight = UITableViewAutomaticDimension;
@@ -55,14 +53,14 @@
 #pragma mark - Navigation
 
 - (void)searchBarCancelButtonClicked:(UISearchBar *)searchBar{
-    [searchBar resignFirstResponder]; // Dismiss the keyboard
-    searchBar.text = @""; // Reset the search bar text
+    [searchBar resignFirstResponder];
+    searchBar.text = @"";
 }
 
 - (void)searchBarSearchButtonClicked:(UISearchBar *)searchBar {
-    [searchBar resignFirstResponder]; // Dismiss the keyboard
+    [searchBar resignFirstResponder];
     NSString *searchText = searchBar.text;
-    searchBar.text = @""; // Reset the search bar text
+    searchBar.text = @"";
     
     [[SUKAPIManager shared] fetchAnimeSearchBySearchQuery:searchText completion:^(NSArray *anime, NSError *error) {
         if (anime != nil) {
@@ -97,7 +95,6 @@
 }
 
 - (IBAction)didTapLogout:(id)sender {
-    // Reset view to the log in screen
     [PFUser logOutInBackgroundWithBlock:^(NSError * _Nullable error) {
         NSLog(@"User log out");
         UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
@@ -179,7 +176,7 @@
             
             int randomGenre1 = arc4random_uniform((int)self.dictOfGenres.count);
             int randomGenre2 = arc4random_uniform((int)self.dictOfGenres.count);
-            while(randomGenre2 == randomGenre1) { // Make sure the two genres are not the same
+            while(randomGenre2 == randomGenre1) { 
                 randomGenre2 = arc4random_uniform((int)self.dictOfGenres.count);
             }
             

--- a/Suko/View Controller/SUKLibraryViewController.m
+++ b/Suko/View Controller/SUKLibraryViewController.m
@@ -12,7 +12,7 @@
 
 @interface SUKLibraryViewController () <UITableViewDataSource, UITableViewDelegate>
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
-@property (nonatomic, strong) NSArray *listTitles;
+@property (nonatomic, strong) NSArray<NSString*> *listTitles;
 
 @end
 

--- a/Suko/View Controller/SUKLibraryViewController.m
+++ b/Suko/View Controller/SUKLibraryViewController.m
@@ -51,7 +51,7 @@
         NSIndexPath *indexPath = [self.tableView indexPathForCell:cell];
         animeListVC.listTitle = cell.listTitleLabel.text;
         animeListVC.arrOfAnimeMALID = [PFUser currentUser][@"list_data"][indexPath.row];
-        animeListVC.arrOfAnime = [NSMutableArray array];
+        animeListVC.arrOfAnime = [NSMutableArray new];
     }
 }
 

--- a/Suko/View Controller/SUKLibraryViewController.m
+++ b/Suko/View Controller/SUKLibraryViewController.m
@@ -51,7 +51,6 @@
         SUKLibraryTableViewCell *cell = sender;
         NSIndexPath *indexPath = [self.tableView indexPathForCell:cell];
         animeListVC.listTitle = cell.listTitleLabel.text;
-        animeListVC.userToDisplay = [PFUser currentUser];
         animeListVC.arrOfAnimeMALID = [PFUser currentUser][@"list_data"][indexPath.row];
         animeListVC.arrOfAnime = [NSMutableArray array];
     }

--- a/Suko/View Controller/SUKLibraryViewController.m
+++ b/Suko/View Controller/SUKLibraryViewController.m
@@ -12,7 +12,7 @@
 
 @interface SUKLibraryViewController () <UITableViewDataSource, UITableViewDelegate>
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
-@property (nonatomic, strong) NSArray<NSString*> *listTitles;
+@property (nonatomic, strong) NSArray<NSString *> *listTitles;
 
 @end
 
@@ -31,12 +31,11 @@
 
 #pragma mark - TableView
 
--(NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section{
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     return [self.listTitles count];
 }
 
-
--(UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath{
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     static NSString *cellIdentifier = @"SUKLibraryTableViewCell";
     SUKLibraryTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:cellIdentifier];
     cell.listTitleLabel.text = self.listTitles[indexPath.row];

--- a/Suko/View Controller/SUKLoginViewController.m
+++ b/Suko/View Controller/SUKLoginViewController.m
@@ -25,7 +25,7 @@
     [self.view addGestureRecognizer:tap];
 }
 
--(void)dismissKeyboard{
+- (void)dismissKeyboard {
     [self.usernameField resignFirstResponder];
     [self.passwordField resignFirstResponder];
 }
@@ -57,7 +57,7 @@
     self.view.window.rootViewController = signupVC;
 }
 
-- (void) checkEmptyField {
+- (void)checkEmptyField {
     if([self.usernameField.text isEqual:@""] || [self.passwordField.text isEqual:@""]) {
         
         NSString *title = @"All fields required";

--- a/Suko/View Controller/SUKLoginViewController.m
+++ b/Suko/View Controller/SUKLoginViewController.m
@@ -36,15 +36,17 @@
     
     [self checkEmptyField];
 
+    __weak __typeof(self) weakSelf = self;
     [PFUser logInWithUsernameInBackground:username password:password block:^(PFUser * user, NSError *  error) {
         if (error != nil) {
             NSLog(@"User log in failed: %@", error.localizedDescription);
         } else {
+            __strong __typeof(self) strongSelf = weakSelf;
             NSLog(@"User logged in successfully");
             // Display view controller that needs to shown after successful login
             UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
             SUKHomeViewController *homeVC = [storyboard instantiateViewControllerWithIdentifier:@"SUKTabController"];
-            self.view.window.rootViewController = homeVC;
+            strongSelf.view.window.rootViewController = homeVC;
         }
     }];
 }

--- a/Suko/View Controller/SUKLoginViewController.m
+++ b/Suko/View Controller/SUKLoginViewController.m
@@ -39,6 +39,15 @@
     __weak __typeof(self) weakSelf = self;
     [PFUser logInWithUsernameInBackground:username password:password block:^(PFUser * user, NSError *  error) {
         if (error != nil) {
+            NSString *title = @"Login failed";
+            NSString *message = [error.localizedDescription stringByAppendingString:@" Please try again."];
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:message
+                                        preferredStyle:(UIAlertControllerStyleAlert)];
+            UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault
+                                                     handler:^(UIAlertAction * _Nonnull action) {}];
+            [alert addAction:okAction];
+            [self presentViewController:alert animated:YES completion:^{}];
+            
             NSLog(@"User log in failed: %@", error.localizedDescription);
         } else {
             __strong __typeof(self) strongSelf = weakSelf;
@@ -59,22 +68,13 @@
 
 - (void)checkEmptyField {
     if([self.usernameField.text isEqual:@""] || [self.passwordField.text isEqual:@""]) {
-        
         NSString *title = @"All fields required";
         NSString *message = @"Please enter a username and password and try again.";
-        
-        UIAlertController *alert = [UIAlertController alertControllerWithTitle:title
-                                    message:message
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:message
                                     preferredStyle:(UIAlertControllerStyleAlert)];
-        // Create an OK action
-        UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK"
-                                                 style:UIAlertActionStyleDefault
+        UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault
                                                  handler:^(UIAlertAction * _Nonnull action) {}];
-        
-        // Add the OK action to the alert controller
         [alert addAction:okAction];
-        
-        // Present the alert
         [self presentViewController:alert animated:YES completion:^{}];
     }
 }

--- a/Suko/View Controller/SUKNotCurrentUserProfileViewController.m
+++ b/Suko/View Controller/SUKNotCurrentUserProfileViewController.m
@@ -119,7 +119,7 @@
         NSIndexPath *indexPath = [self.tableView indexPathForCell:cell];
         animeListVC.listTitle = cell.listTitleLabel.text;
         animeListVC.arrOfAnimeMALID = self.userToDisplay[@"list_data"][indexPath.row];
-        animeListVC.arrOfAnime = [NSMutableArray array];
+        animeListVC.arrOfAnime = [NSMutableArray new];
     }
 }
 

--- a/Suko/View Controller/SUKNotCurrentUserProfileViewController.m
+++ b/Suko/View Controller/SUKNotCurrentUserProfileViewController.m
@@ -47,8 +47,12 @@
     // Load the username
     self.usernameLabel.text = [@"@" stringByAppendingString:self.userToDisplay.username];
     
-    self.followButton.layer.cornerRadius = 4;
-    self.followButton.layer.masksToBounds = true;
+    if([self.userToDisplay.objectId isEqualToString:[PFUser currentUser].objectId]) {
+        [self.followButton removeFromSuperview];
+    } else {
+        self.followButton.layer.cornerRadius = 4;
+        self.followButton.layer.masksToBounds = true;
+    }
     
     PFQuery *query = [PFQuery queryWithClassName:@"SUKFollow"];
     [query whereKey:@"follower" equalTo:[PFUser currentUser]];

--- a/Suko/View Controller/SUKNotCurrentUserProfileViewController.m
+++ b/Suko/View Controller/SUKNotCurrentUserProfileViewController.m
@@ -78,7 +78,7 @@
             [SUKFollow deleteFollow:[follows lastObject]];
             [self.followButton setTitle:@"Follow" forState:UIControlStateNormal];
         } else {
-            [SUKFollow postFollow:[PFUser currentUser] userBeingFollowed:self.userToDisplay withCompletion:^(BOOL succeeded, NSError * error) {
+            [SUKFollow postFollowWithFollower:[PFUser currentUser] userBeingFollowed:self.userToDisplay withCompletion:^(BOOL succeeded, NSError * error) {
                 if (succeeded) {
                     NSLog(@"The follow was uploaded!");
                     [self.followButton setTitle:@"Following" forState:UIControlStateNormal];

--- a/Suko/View Controller/SUKNotCurrentUserProfileViewController.m
+++ b/Suko/View Controller/SUKNotCurrentUserProfileViewController.m
@@ -15,7 +15,7 @@
 @interface SUKNotCurrentUserProfileViewController () <UITableViewDataSource, UITableViewDelegate>
 @property (weak, nonatomic) IBOutlet PFImageView *profileImageView;
 @property (weak, nonatomic) IBOutlet UILabel *usernameLabel;
-@property (nonatomic, strong) NSArray<NSString*> *listTitles;
+@property (nonatomic, strong) NSArray<NSString *> *listTitles;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
 @property (weak, nonatomic) IBOutlet UIButton *followButton;
 
@@ -36,15 +36,13 @@
     [self loadContents];
 }
 
--(void) loadContents {
-    // Load the user profile image
+- (void)loadContents {
     self.profileImageView.file = self.userToDisplay[@"profile_image"];
     [self.profileImageView loadInBackground];
     self.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.height /2;
     self.profileImageView.layer.masksToBounds = YES;
     self.profileImageView.layer.borderWidth = 0;
     
-    // Load the username
     self.usernameLabel.text = [@"@" stringByAppendingString:self.userToDisplay.username];
     
     if([self.userToDisplay.objectId isEqualToString:[PFUser currentUser].objectId]) {
@@ -59,7 +57,7 @@
     [query whereKey:@"userBeingFollowed" equalTo:self.userToDisplay];
     
     __weak __typeof(self) weakSelf = self;
-    [query findObjectsInBackgroundWithBlock:^(NSArray<SUKFollow*> *follows, NSError *error) {
+    [query findObjectsInBackgroundWithBlock:^(NSArray<SUKFollow *> *follows, NSError *error) {
         __strong __typeof(self) strongSelf = weakSelf;
         if([follows count] > 1) {
             NSLog(@"Error: More than one follow relationship between current user and user being displayed");
@@ -78,7 +76,7 @@
     [query whereKey:@"userBeingFollowed" equalTo:self.userToDisplay];
     
     __weak __typeof(self) weakSelf = self;
-    [query findObjectsInBackgroundWithBlock:^(NSArray<SUKFollow*> *follows, NSError *error) {
+    [query findObjectsInBackgroundWithBlock:^(NSArray<SUKFollow *> *follows, NSError *error) {
         __strong __typeof(self) strongSelf = weakSelf;
         if([follows count] > 1) {
             NSLog(@"Error: More than one follow relationship between current user and user being displayed");
@@ -101,11 +99,11 @@
 
 #pragma mark - TableView
 
--(NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section{
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     return [self.listTitles count];
 }
 
--(UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath{
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     static NSString *cellIdentifier = @"SUKLibraryTableViewCell";
     SUKLibraryTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:cellIdentifier];
     cell.listTitleLabel.text = self.listTitles[indexPath.row];

--- a/Suko/View Controller/SUKNotCurrentUserProfileViewController.m
+++ b/Suko/View Controller/SUKNotCurrentUserProfileViewController.m
@@ -58,13 +58,15 @@
     [query whereKey:@"follower" equalTo:[PFUser currentUser]];
     [query whereKey:@"userBeingFollowed" equalTo:self.userToDisplay];
     
+    __weak __typeof(self) weakSelf = self;
     [query findObjectsInBackgroundWithBlock:^(NSArray<SUKFollow*> *follows, NSError *error) {
+        __strong __typeof(self) strongSelf = weakSelf;
         if([follows count] > 1) {
             NSLog(@"Error: More than one follow relationship between current user and user being displayed");
         } else if([follows count] == 1) {
-            [self.followButton setTitle:@"Following" forState:UIControlStateNormal];
+            [strongSelf.followButton setTitle:@"Following" forState:UIControlStateNormal];
         } else {
-            [self.followButton setTitle:@"Follow" forState:UIControlStateNormal];
+            [strongSelf.followButton setTitle:@"Follow" forState:UIControlStateNormal];
         }
     }];
 }
@@ -75,17 +77,20 @@
     [query whereKey:@"follower" equalTo:[PFUser currentUser]];
     [query whereKey:@"userBeingFollowed" equalTo:self.userToDisplay];
     
+    __weak __typeof(self) weakSelf = self;
     [query findObjectsInBackgroundWithBlock:^(NSArray<SUKFollow*> *follows, NSError *error) {
+        __strong __typeof(self) strongSelf = weakSelf;
         if([follows count] > 1) {
             NSLog(@"Error: More than one follow relationship between current user and user being displayed");
         } else if([follows count] == 1) {
             [SUKFollow deleteFollow:[follows lastObject]];
-            [self.followButton setTitle:@"Follow" forState:UIControlStateNormal];
+            [strongSelf.followButton setTitle:@"Follow" forState:UIControlStateNormal];
         } else {
             [SUKFollow postFollowWithFollower:[PFUser currentUser] userBeingFollowed:self.userToDisplay withCompletion:^(BOOL succeeded, NSError * error) {
+                __strong __typeof(self) strongSelf = weakSelf;
                 if (succeeded) {
                     NSLog(@"The follow was uploaded!");
-                    [self.followButton setTitle:@"Following" forState:UIControlStateNormal];
+                    [strongSelf.followButton setTitle:@"Following" forState:UIControlStateNormal];
                 } else {
                     NSLog(@"Problem uploading the event: %@", error.localizedDescription);
                 }

--- a/Suko/View Controller/SUKNotCurrentUserProfileViewController.m
+++ b/Suko/View Controller/SUKNotCurrentUserProfileViewController.m
@@ -15,7 +15,7 @@
 @interface SUKNotCurrentUserProfileViewController () <UITableViewDataSource, UITableViewDelegate>
 @property (weak, nonatomic) IBOutlet PFImageView *profileImageView;
 @property (weak, nonatomic) IBOutlet UILabel *usernameLabel;
-@property (nonatomic, strong) NSArray *listTitles;
+@property (nonatomic, strong) NSArray<NSString*> *listTitles;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
 @property (weak, nonatomic) IBOutlet UIButton *followButton;
 

--- a/Suko/View Controller/SUKNotCurrentUserProfileViewController.m
+++ b/Suko/View Controller/SUKNotCurrentUserProfileViewController.m
@@ -115,7 +115,6 @@
         SUKLibraryTableViewCell *cell = sender;
         NSIndexPath *indexPath = [self.tableView indexPathForCell:cell];
         animeListVC.listTitle = cell.listTitleLabel.text;
-        animeListVC.userToDisplay = self.userToDisplay;
         animeListVC.arrOfAnimeMALID = self.userToDisplay[@"list_data"][indexPath.row];
         animeListVC.arrOfAnime = [NSMutableArray array];
     }

--- a/Suko/View Controller/SUKProfileViewController.m
+++ b/Suko/View Controller/SUKProfileViewController.m
@@ -18,7 +18,7 @@
 @property (weak, nonatomic) IBOutlet PFImageView *profileImageView;
 @property (weak, nonatomic) IBOutlet UILabel *usernameLabel;
 @property (nonatomic, strong) UIBarButtonItem *logoutButton;
-@property (nonatomic, strong) NSArray<NSString*> *listTitles;
+@property (nonatomic, strong) NSArray<NSString *> *listTitles;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
 
 @end
@@ -47,7 +47,7 @@
     [self loadContents];
 }
 
--(void) loadContents {
+- (void)loadContents {
     // Load the user profile image
     self.profileImageView.file = [PFUser currentUser][@"profile_image"];
     [self.profileImageView loadInBackground];
@@ -61,7 +61,7 @@
 
 #pragma mark - TableView
 
--(NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section{
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     return [self.listTitles count];
 }
 
@@ -72,7 +72,7 @@
     return cell;
 }
 
--(void) tapLogout {
+- (void)tapLogout {
     NSLog(@"User tapped log out");
     
     __weak __typeof(self) weakSelf = self;

--- a/Suko/View Controller/SUKProfileViewController.m
+++ b/Suko/View Controller/SUKProfileViewController.m
@@ -75,11 +75,12 @@
 -(void) tapLogout {
     NSLog(@"User tapped log out");
     
-    // Reset view to the log in screen
+    __weak __typeof(self) weakSelf = self;
     [PFUser logOutInBackgroundWithBlock:^(NSError * _Nullable error) {
+        __strong __typeof(self) strongSelf = weakSelf;
         UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
         SUKLoginViewController *loginVC = [storyboard instantiateViewControllerWithIdentifier:@"LoginVC"];
-        self.view.window.rootViewController = loginVC;
+        strongSelf.view.window.rootViewController = loginVC;
     }];
 }
 

--- a/Suko/View Controller/SUKProfileViewController.m
+++ b/Suko/View Controller/SUKProfileViewController.m
@@ -91,7 +91,7 @@
         NSIndexPath *indexPath = [self.tableView indexPathForCell:cell];
         animeListVC.listTitle = cell.listTitleLabel.text;
         animeListVC.arrOfAnimeMALID = [PFUser currentUser][@"list_data"][indexPath.row];
-        animeListVC.arrOfAnime = [NSMutableArray array];
+        animeListVC.arrOfAnime = [NSMutableArray new];
     }
 }
 

--- a/Suko/View Controller/SUKProfileViewController.m
+++ b/Suko/View Controller/SUKProfileViewController.m
@@ -89,7 +89,6 @@
         SUKLibraryTableViewCell *cell = sender;
         NSIndexPath *indexPath = [self.tableView indexPathForCell:cell];
         animeListVC.listTitle = cell.listTitleLabel.text;
-        animeListVC.userToDisplay = [PFUser currentUser];
         animeListVC.arrOfAnimeMALID = [PFUser currentUser][@"list_data"][indexPath.row];
         animeListVC.arrOfAnime = [NSMutableArray array];
     }

--- a/Suko/View Controller/SUKProfileViewController.m
+++ b/Suko/View Controller/SUKProfileViewController.m
@@ -18,7 +18,7 @@
 @property (weak, nonatomic) IBOutlet PFImageView *profileImageView;
 @property (weak, nonatomic) IBOutlet UILabel *usernameLabel;
 @property (nonatomic, strong) UIBarButtonItem *logoutButton;
-@property (nonatomic, strong) NSArray *listTitles;
+@property (nonatomic, strong) NSArray<NSString*> *listTitles;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
 
 @end
@@ -35,7 +35,7 @@
     self.tableView.rowHeight = UITableViewAutomaticDimension;
     
     self.logoutButton = [[UIBarButtonItem alloc] initWithTitle:@"Logout" style:UIBarButtonItemStylePlain target:self action:@selector(tapLogout)];
-    NSMutableArray* currentRightBarItemsMutable = [self.navigationItem.rightBarButtonItems mutableCopy];
+    NSMutableArray<UIBarButtonItem *>* currentRightBarItemsMutable = [self.navigationItem.rightBarButtonItems mutableCopy];
     [currentRightBarItemsMutable addObject:self.logoutButton];
     self.navigationItem.rightBarButtonItems = [currentRightBarItemsMutable copy];
         

--- a/Suko/View Controller/SUKQuizViewController.h
+++ b/Suko/View Controller/SUKQuizViewController.h
@@ -1,0 +1,16 @@
+//
+//  SUKQuizViewController.h
+//  Suko
+//
+//  Created by Alice Zhang on 7/20/22.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SUKQuizViewController : UIViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Suko/View Controller/SUKQuizViewController.m
+++ b/Suko/View Controller/SUKQuizViewController.m
@@ -15,17 +15,5 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    // Do any additional setup after loading the view.
 }
-
-/*
-#pragma mark - Navigation
-
-// In a storyboard-based application, you will often want to do a little preparation before navigation
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    // Get the new view controller using [segue destinationViewController].
-    // Pass the selected object to the new view controller.
-}
-*/
-
 @end

--- a/Suko/View Controller/SUKQuizViewController.m
+++ b/Suko/View Controller/SUKQuizViewController.m
@@ -1,0 +1,31 @@
+//
+//  SUKQuizViewController.m
+//  Suko
+//
+//  Created by Alice Zhang on 7/20/22.
+//
+
+#import "SUKQuizViewController.h"
+
+@interface SUKQuizViewController ()
+
+@end
+
+@implementation SUKQuizViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+}
+
+/*
+#pragma mark - Navigation
+
+// In a storyboard-based application, you will often want to do a little preparation before navigation
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+    // Get the new view controller using [segue destinationViewController].
+    // Pass the selected object to the new view controller.
+}
+*/
+
+@end

--- a/Suko/View Controller/SUKSignUpViewController.m
+++ b/Suko/View Controller/SUKSignUpViewController.m
@@ -42,16 +42,16 @@
     newUser.username = self.usernameField.text;
     newUser.password = self.passwordField.text;
     
-    newUser[@"list_titles"] = [NSMutableArray array];
+    newUser[@"list_titles"] = [NSMutableArray new];
     [newUser[@"list_titles"] addObject:@"Want to Watch"];
     [newUser[@"list_titles"] addObject:@"Watching"];
     [newUser[@"list_titles"] addObject:@"Watched"];
     
     newUser[@"follower_arr"] = [NSArray new];
     
-    newUser[@"list_data"] = [NSMutableArray array];
+    newUser[@"list_data"] = [NSMutableArray new];
     for(int i = 0; i < [newUser[@"list_titles"] count]; i++) {
-        [newUser[@"list_data"] addObject:[NSMutableArray array]];
+        [newUser[@"list_data"] addObject:[NSMutableArray new]];
     }
     
     [self checkEmptyField];

--- a/Suko/View Controller/SUKSignUpViewController.m
+++ b/Suko/View Controller/SUKSignUpViewController.m
@@ -56,16 +56,17 @@
     
     [self checkEmptyField];
     
-    // Call sign up function on the object
+    __weak __typeof(self) weakSelf = self;
     [newUser signUpInBackgroundWithBlock:^(BOOL succeeded, NSError * error) {
         if (error != nil) {
             NSLog(@"Error: %@", error.localizedDescription);
         } else {
+            __strong __typeof(self) strongSelf = weakSelf;
             NSLog(@"User registered successfully");
             // Display view controller that needs to shown after successful login
             UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
             SUKHomeViewController *homeVC = [storyboard instantiateViewControllerWithIdentifier:@"SUKTabController"];
-            self.view.window.rootViewController = homeVC;
+            strongSelf.view.window.rootViewController = homeVC;
         }
     }];
 }

--- a/Suko/View Controller/SUKSignUpViewController.m
+++ b/Suko/View Controller/SUKSignUpViewController.m
@@ -27,7 +27,7 @@
     [self.view addGestureRecognizer:tap];
 }
 
--(void)dismissKeyboard{
+- (void)dismissKeyboard{
     [self.emailField resignFirstResponder];
     [self.usernameField resignFirstResponder];
     [self.passwordField resignFirstResponder];
@@ -77,7 +77,7 @@
     self.view.window.rootViewController = loginVC;
 }
 
-- (void) checkEmptyField {
+- (void)checkEmptyField {
     if([self.emailField.text isEqual:@""] || [self.usernameField.text isEqual:@""] || [self.passwordField.text isEqual:@""]) {
         
         NSString *title = @"All fields required";

--- a/Suko/View Controller/SUKSignUpViewController.m
+++ b/Suko/View Controller/SUKSignUpViewController.m
@@ -47,7 +47,7 @@
     [newUser[@"list_titles"] addObject:@"Watching"];
     [newUser[@"list_titles"] addObject:@"Watched"];
     
-    newUser[@"follower_arr"] = [[NSArray alloc] init];
+    newUser[@"follower_arr"] = [NSArray new];
     
     newUser[@"list_data"] = [NSMutableArray array];
     for(int i = 0; i < [newUser[@"list_titles"] count]; i++) {

--- a/Suko/View Controller/SUKUserMapViewController.h
+++ b/Suko/View Controller/SUKUserMapViewController.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SUKUserMapViewController : UIViewController
 
+extern NSString *const kMapToNotCurrentUserProfileSegueIdentifier;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Suko/View Controller/SUKUserMapViewController.m
+++ b/Suko/View Controller/SUKUserMapViewController.m
@@ -37,7 +37,7 @@
     [self.locationManager startUpdatingLocation];
 }
 
-- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations {
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation*>*)locations {
     self.currentUserLocation = [locations lastObject];
     
     MKCoordinateRegion currentUserRegion = MKCoordinateRegionMake(self.currentUserLocation.coordinate, MKCoordinateSpanMake(0.01, 0.01));

--- a/Suko/View Controller/SUKUserMapViewController.m
+++ b/Suko/View Controller/SUKUserMapViewController.m
@@ -57,16 +57,18 @@
     [query includeKey:@"current_coordinates"];
     [query whereKey:@"current_coordinates" nearGeoPoint:[PFUser currentUser][@"current_coordinates"] withinMiles:2.0];
     
+    __weak __typeof(self) weakSelf = self;
     [query findObjectsInBackgroundWithBlock:^(NSArray<PFUser *> *users, NSError *error) {
+        __strong __typeof(self) strongSelf = weakSelf;
         for(PFUser *user in users) {
             if(![user.objectId isEqualToString:[PFUser currentUser].objectId]) {
-                [self.nearestUsersArr addObject:user];
+                [strongSelf.nearestUsersArr addObject:user];
                 
                 MKPointAnnotation *annotation = [MKPointAnnotation new];
                 PFGeoPoint *user_coordinates = user[@"current_coordinates"];
                 annotation.coordinate = CLLocationCoordinate2DMake(user_coordinates.latitude, user_coordinates.longitude);
                 annotation.title = user.username;
-                [self.mapView addAnnotation:annotation];
+                [strongSelf.mapView addAnnotation:annotation];
                 
             }
         }
@@ -79,12 +81,14 @@
     PFQuery *query = [PFQuery queryWithClassName:@"_User"];
     [query whereKey:@"username" equalTo:title];
     
+    __weak __typeof(self) weakSelf = self;
     [query findObjectsInBackgroundWithBlock:^(NSArray<PFUser *> *users, NSError *error) {
+        __strong __typeof(self) strongSelf = weakSelf;
         if(users.count > 1) {
             NSLog(@"Error: More than one user with the username");
         } else {
-            [self.mapView deselectAnnotation:view.annotation animated:YES];
-            [self performSegueWithIdentifier:@"MapToNotCurrentUserProfileSegue" sender:[users lastObject]];
+            [strongSelf.mapView deselectAnnotation:view.annotation animated:YES];
+            [strongSelf performSegueWithIdentifier:@"MapToNotCurrentUserProfileSegue" sender:[users lastObject]];
         }
     }];
 }

--- a/Suko/View Controller/SUKUserMapViewController.m
+++ b/Suko/View Controller/SUKUserMapViewController.m
@@ -26,7 +26,7 @@
     
     self.mapView.delegate = self;
     
-    self.locationManager = [[CLLocationManager alloc] init];
+    self.locationManager = [CLLocationManager new];
     self.locationManager.delegate = self;
     self.locationManager.distanceFilter = kCLDistanceFilterNone;
     self.locationManager.desiredAccuracy = kCLLocationAccuracyBest;

--- a/Suko/View Controller/SUKUserMapViewController.m
+++ b/Suko/View Controller/SUKUserMapViewController.m
@@ -39,7 +39,7 @@ NSString *const kMapToNotCurrentUserProfileSegueIdentifier = @"MapToNotCurrentUs
     [self.locationManager startUpdatingLocation];
 }
 
-- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation*>*)locations {
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray<CLLocation *> *)locations {
     self.currentUserLocation = [locations lastObject];
     
     MKCoordinateRegion currentUserRegion = MKCoordinateRegionMake(self.currentUserLocation.coordinate, MKCoordinateSpanMake(0.01, 0.01));
@@ -71,7 +71,6 @@ NSString *const kMapToNotCurrentUserProfileSegueIdentifier = @"MapToNotCurrentUs
                 annotation.coordinate = CLLocationCoordinate2DMake(user_coordinates.latitude, user_coordinates.longitude);
                 annotation.title = user.username;
                 [strongSelf.mapView addAnnotation:annotation];
-                
             }
         }
     }];

--- a/Suko/View Controller/SUKUserMapViewController.m
+++ b/Suko/View Controller/SUKUserMapViewController.m
@@ -21,6 +21,8 @@
 
 @implementation SUKUserMapViewController
 
+NSString *const kMapToNotCurrentUserProfileSegueIdentifier = @"MapToNotCurrentUserProfileSegue";
+
 - (void)viewDidLoad {
     [super viewDidLoad];
     
@@ -88,13 +90,13 @@
             NSLog(@"Error: More than one user with the username");
         } else {
             [strongSelf.mapView deselectAnnotation:view.annotation animated:YES];
-            [strongSelf performSegueWithIdentifier:@"MapToNotCurrentUserProfileSegue" sender:[users lastObject]];
+            [strongSelf performSegueWithIdentifier:kMapToNotCurrentUserProfileSegueIdentifier sender:[users lastObject]];
         }
     }];
 }
 
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    if([segue.identifier isEqualToString:@"MapToNotCurrentUserProfileSegue"]) {
+    if([segue.identifier isEqualToString:kMapToNotCurrentUserProfileSegueIdentifier]) {
         SUKNotCurrentUserProfileViewController *notCurrentUserprofileVC = [segue destinationViewController];
         notCurrentUserprofileVC.userToDisplay = sender;
     }


### PR DESCRIPTION
### Summary
- When a user taps on the "Registered" segment, only events they have registered for is displayed.
- When a user pulls down on the browse event view controller, the data displayed is refreshed according to which segment is selected.
- When a user taps on the the event host's profile picture or username, the event host's profile is shown. If the event host is the current user, the follow button is removed from the shown profile.

### Test Plan

https://user-images.githubusercontent.com/53063545/180076790-0f87878e-77a0-4466-8fe3-590e616396c9.MP4

